### PR TITLE
fix(router): use standard HTTP status text instead of arbitrary statu…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.0.0-beta.3",
             "license": "MIT",
             "dependencies": {
-                "@ebec/http": "^3.1.0",
+                "@ebec/http": "^4.0.0",
                 "mime-explorer": "^1.1.0",
                 "negotiator": "^1.0.0",
                 "path-to-regexp": "^8.4.2",
@@ -461,9 +461,9 @@
             "license": "MIT"
         },
         "node_modules/@ebec/http": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@ebec/http/-/http-3.1.0.tgz",
-            "integrity": "sha512-aVtX4FQ4T1Y6B+oJl2ra+OeaCnPfMRkWuyhm4e1IpWqJB+kuFWxun4PsW7D765/d48+BxJRv+OjlQLNwOuhH6A==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@ebec/http/-/http-4.0.0.tgz",
+            "integrity": "sha512-3nzhuWuTWXBAVe+nd3WCqU33IZdNU3aRqFvY4/G96T10DSx/AE63yXnFxpERxz9Ib20JhWXWwhAEAK9zQME59g==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.0.0-beta.3",
             "license": "MIT",
             "dependencies": {
-                "@ebec/http": "^3.0.3",
+                "@ebec/http": "^3.1.0",
                 "mime-explorer": "^1.1.0",
                 "negotiator": "^1.0.0",
                 "path-to-regexp": "^8.4.2",
@@ -461,9 +461,9 @@
             "license": "MIT"
         },
         "node_modules/@ebec/http": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@ebec/http/-/http-3.0.3.tgz",
-            "integrity": "sha512-GSs7yOLfZzZAJ6jYfRlL64ORgQcu2NCj2V6IfQStU+n5+QMiLU9V+lBR7PKJuqt66kFSLC++iLlChPU/w/a/Lg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@ebec/http/-/http-3.1.0.tgz",
+            "integrity": "sha512-aVtX4FQ4T1Y6B+oJl2ra+OeaCnPfMRkWuyhm4e1IpWqJB+kuFWxun4PsW7D765/d48+BxJRv+OjlQLNwOuhH6A==",
             "license": "MIT",
             "dependencies": {
                 "@ebec/core": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     },
     "homepage": "https://github.com/routup/routup#readme",
     "dependencies": {
-        "@ebec/http": "^3.1.0",
+        "@ebec/http": "^4.0.0",
         "mime-explorer": "^1.1.0",
         "negotiator": "^1.0.0",
         "path-to-regexp": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     },
     "homepage": "https://github.com/routup/routup#readme",
     "dependencies": {
-        "@ebec/http": "^3.0.3",
+        "@ebec/http": "^3.1.0",
         "mime-explorer": "^1.1.0",
         "negotiator": "^1.0.0",
         "path-to-regexp": "^8.4.2",

--- a/src/error/create.ts
+++ b/src/error/create.ts
@@ -15,7 +15,7 @@ function isNativeError(input: unknown): input is Error {
  * - an existing RoutupError (returned as-is)
  * - an HTTPError (wrapped into a RoutupError preserving status)
  * - an Error (wrapped preserving message and cause)
- * - an options object (status, statusMessage, etc.)
+ * - an options object (status, message, etc.)
  * - a message string
  *
  * @param input
@@ -34,7 +34,6 @@ export function createError(input: HTTPErrorInput | unknown) : RoutupError {
             message: input.message,
             code: input.code,
             status: input.status,
-            statusMessage: input.statusMessage,
             redirectURL: input.redirectURL,
             cause: input,
         });

--- a/src/error/create.ts
+++ b/src/error/create.ts
@@ -15,7 +15,7 @@ function isNativeError(input: unknown): input is Error {
  * - an existing RoutupError (returned as-is)
  * - an HTTPError (wrapped into a RoutupError preserving status)
  * - an Error (wrapped preserving message and cause)
- * - an options object (statusCode, statusMessage, etc.)
+ * - an options object (status, statusMessage, etc.)
  * - a message string
  *
  * @param input
@@ -33,7 +33,7 @@ export function createError(input: HTTPErrorInput | unknown) : RoutupError {
         return new RoutupError({
             message: input.message,
             code: input.code,
-            statusCode: input.statusCode,
+            status: input.status,
             statusMessage: input.statusMessage,
             redirectURL: input.redirectURL,
             cause: input,

--- a/src/event/types.ts
+++ b/src/event/types.ts
@@ -4,7 +4,6 @@ import type { RouterOptions } from '../router/types.ts';
 export type RoutupResponse = {
     status: number;
     headers: Headers;
-    statusText?: string
 };
 
 export type RoutupRequest = ServerRequest;

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -214,7 +214,7 @@ export class Handler implements IDispatcher {
                         }
                         reject(createError({
                             status: 408,
-                            statusMessage: 'Request Timeout',
+                            message: 'Request Timeout',
                         }));
                     }, effectiveTimeout);
                 }),

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -213,7 +213,7 @@ export class Handler implements IDispatcher {
                             controller.abort();
                         }
                         reject(createError({
-                            statusCode: 408,
+                            status: 408,
                             statusMessage: 'Request Timeout',
                         }));
                     }, effectiveTimeout);

--- a/src/response/helpers/event-stream/module.ts
+++ b/src/response/helpers/event-stream/module.ts
@@ -45,7 +45,6 @@ export function createEventStream(
 
     const response = new Response(stream, {
         status: event.response.status,
-        statusText: event.response.statusText,
         headers,
     });
 

--- a/src/response/helpers/send-accepted.ts
+++ b/src/response/helpers/send-accepted.ts
@@ -3,7 +3,6 @@ import { toResponse } from '../to-response.ts';
 
 export async function sendAccepted(event: IRoutupEvent, data?: unknown): Promise<Response> {
     event.response.status = 202;
-    event.response.statusText = 'Accepted';
 
     return await toResponse(data ?? '', event) as Response;
 }

--- a/src/response/helpers/send-created.ts
+++ b/src/response/helpers/send-created.ts
@@ -3,7 +3,6 @@ import { toResponse } from '../to-response.ts';
 
 export async function sendCreated(event: IRoutupEvent, data?: unknown): Promise<Response> {
     event.response.status = 201;
-    event.response.statusText = 'Created';
 
     return await toResponse(data ?? '', event) as Response;
 }

--- a/src/response/helpers/send-file.ts
+++ b/src/response/helpers/send-file.ts
@@ -71,7 +71,6 @@ export async function sendFile(
                 rangeHeaders.set(HeaderName.CONTENT_RANGE, `bytes */${stats.size}`);
                 return new Response(null, {
                     status: 416,
-                    statusText: event.response.statusText,
                     headers: rangeHeaders,
                 });
             }
@@ -96,7 +95,6 @@ export async function sendFile(
 
     return new Response(content as BodyInit, {
         status: statusCode,
-        statusText: event.response.statusText,
         headers,
     });
 }

--- a/src/response/helpers/send-redirect.ts
+++ b/src/response/helpers/send-redirect.ts
@@ -31,7 +31,7 @@ function isAllowedRedirectUrl(location: string) : boolean {
 export function sendRedirect(event: IRoutupEvent, location: string, statusCode = 302): Response {
     if (!isAllowedRedirectUrl(location)) {
         throw new RoutupError({
-            statusCode: 400,
+            status: 400,
             statusMessage: 'Invalid redirect URL scheme.',
         });
     }

--- a/src/response/helpers/send-redirect.ts
+++ b/src/response/helpers/send-redirect.ts
@@ -32,7 +32,7 @@ export function sendRedirect(event: IRoutupEvent, location: string, statusCode =
     if (!isAllowedRedirectUrl(location)) {
         throw new RoutupError({
             status: 400,
-            statusMessage: 'Invalid redirect URL scheme.',
+            message: 'Invalid redirect URL scheme.',
         });
     }
 
@@ -47,7 +47,6 @@ export function sendRedirect(event: IRoutupEvent, location: string, statusCode =
 
     const response = new Response(html, {
         status: statusCode,
-        statusText: event.response.statusText,
         headers,
     });
 

--- a/src/response/helpers/send-stream.ts
+++ b/src/response/helpers/send-stream.ts
@@ -3,13 +3,11 @@ import type { IRoutupEvent } from '../../event/index.ts';
 export function sendStream(event: IRoutupEvent, stream: ReadableStream): Response {
     const {
         status,
-        statusText,
         headers,
     } = event.response;
 
     return new Response(stream, {
         status,
-        statusText,
         headers,
     });
 }

--- a/src/response/to-response.ts
+++ b/src/response/to-response.ts
@@ -111,7 +111,7 @@ export async function toResponse(
     } catch (e) {
         throw createError({
             message: 'JSON serialization failed',
-            statusCode: 500,
+            status: 500,
             cause: e,
         });
     }

--- a/src/response/to-response.ts
+++ b/src/response/to-response.ts
@@ -40,7 +40,6 @@ export async function toResponse(
     if (value === null) {
         return new Response(null, {
             status: event.response.status,
-            statusText: event.response.statusText,
             headers: event.response.headers,
         });
     }
@@ -52,7 +51,6 @@ export async function toResponse(
     const {
         status,
         headers,
-        statusText,
     } = event.response;
 
     if (typeof value === 'string') {
@@ -65,7 +63,6 @@ export async function toResponse(
 
         return new Response(value, {
             status,
-            statusText,
             headers,
         });
     }
@@ -76,7 +73,6 @@ export async function toResponse(
         }
         return new Response(value as BodyInit, {
             status,
-            statusText,
             headers,
         });
     }
@@ -84,7 +80,6 @@ export async function toResponse(
     if (value instanceof ReadableStream) {
         return new Response(value, {
             status,
-            statusText,
             headers,
         });
     }
@@ -95,7 +90,6 @@ export async function toResponse(
         }
         return new Response(value, {
             status,
-            statusText,
             headers,
         });
     }
@@ -121,7 +115,6 @@ export async function toResponse(
 
     return new Response(json, {
         status,
-        statusText,
         headers,
     });
 }

--- a/src/router/module.ts
+++ b/src/router/module.ts
@@ -1,3 +1,4 @@
+import { getStatusText } from '@ebec/http';
 import { HeaderName, MethodName } from '../constants.ts';
 import { DispatcherEvent } from '../dispatcher/index.ts';
 import type { IDispatcherEvent } from '../dispatcher/index.ts';
@@ -130,7 +131,7 @@ export class Router implements IRouter {
                             timerId = setTimeout(() => {
                                 controller.abort();
                                 reject(createError({
-                                    statusCode: 408,
+                                    status: 408,
                                     statusMessage: 'Request Timeout',
                                 }));
                             }, timeoutMs);
@@ -151,8 +152,8 @@ export class Router implements IRouter {
         }
 
         if (event.error) {
-            const status = event.error.statusCode || 500;
-            const message = event.error.statusMessage || 'Internal Server Error';
+            const status = event.error.status || 500;
+            const message = event.error.statusMessage || getStatusText(status) || 'Unknown Error';
             return this.buildFallbackResponse(request, event, status, message);
         }
 
@@ -161,12 +162,13 @@ export class Router implements IRouter {
 
     protected buildFallbackResponse(request: RoutupRequest, event: IDispatcherEvent, status: number, message: string): Response {
         const headers = new Headers(event.response.headers);
+        const statusText = getStatusText(status) || 'Unknown Error';
 
         if (acceptsJson(request)) {
             headers.set('content-type', 'application/json; charset=utf-8');
             return new Response(JSON.stringify({ status, message }), {
                 status,
-                statusText: message,
+                statusText,
                 headers,
             });
         }
@@ -174,7 +176,7 @@ export class Router implements IRouter {
         headers.set('content-type', 'text/plain; charset=utf-8');
         return new Response(message, {
             status,
-            statusText: message,
+            statusText,
             headers,
         });
     }

--- a/src/router/module.ts
+++ b/src/router/module.ts
@@ -1,4 +1,3 @@
-import { getStatusText } from '@ebec/http';
 import { HeaderName, MethodName } from '../constants.ts';
 import { DispatcherEvent } from '../dispatcher/index.ts';
 import type { IDispatcherEvent } from '../dispatcher/index.ts';
@@ -132,7 +131,7 @@ export class Router implements IRouter {
                                 controller.abort();
                                 reject(createError({
                                     status: 408,
-                                    statusMessage: 'Request Timeout',
+                                    message: 'Request Timeout',
                                 }));
                             }, timeoutMs);
                         }),
@@ -152,9 +151,12 @@ export class Router implements IRouter {
         }
 
         if (event.error) {
-            const status = event.error.status || 500;
-            const message = event.error.statusMessage || getStatusText(status) || 'Unknown Error';
-            return this.buildFallbackResponse(request, event, status, message);
+            return this.buildFallbackResponse(
+                request,
+                event,
+                event.error.status || 500,
+                event.error.message,
+            );
         }
 
         return this.buildFallbackResponse(request, event, 404, 'Not Found');
@@ -162,13 +164,11 @@ export class Router implements IRouter {
 
     protected buildFallbackResponse(request: RoutupRequest, event: IDispatcherEvent, status: number, message: string): Response {
         const headers = new Headers(event.response.headers);
-        const statusText = getStatusText(status) || 'Unknown Error';
 
         if (acceptsJson(request)) {
             headers.set('content-type', 'application/json; charset=utf-8');
             return new Response(JSON.stringify({ status, message }), {
                 status,
-                statusText,
                 headers,
             });
         }
@@ -176,7 +176,6 @@ export class Router implements IRouter {
         headers.set('content-type', 'text/plain; charset=utf-8');
         return new Response(message, {
             status,
-            statusText,
             headers,
         });
     }
@@ -364,7 +363,6 @@ export class Router implements IRouter {
             optionsHeaders.set(HeaderName.ALLOW, options);
             context.response = new Response(options, {
                 status: context.event.response.status || 200,
-                statusText: context.event.response.statusText,
                 headers: optionsHeaders,
             });
 

--- a/test/unit/error/chain.spec.ts
+++ b/test/unit/error/chain.spec.ts
@@ -18,7 +18,7 @@ describe('error context preservation', () => {
         const response = await router.fetch(createTestRequest('/'));
 
         expect(response.status).toEqual(500);
-        expect(await response.text()).toContain('Internal Server Error');
+        expect(await response.text()).toContain('plain error in hook');
     });
 
     it('should preserve original error when error handler throws', async () => {
@@ -26,7 +26,7 @@ describe('error context preservation', () => {
         const capturedErrors: RoutupError[] = [];
 
         router.use(defineCoreHandler(() => {
-            throw new RoutupError({ status: 400, statusMessage: 'Bad Request' });
+            throw new RoutupError({ status: 400, message: 'Bad Request' });
         }));
 
         router.on('error', () => {
@@ -46,18 +46,18 @@ describe('error context preservation', () => {
         // The original error is preserved — not overwritten by the hook error
         expect(capturedErrors.length).toBeGreaterThan(0);
         expect(capturedErrors[0]!.status).toEqual(400);
-        expect(capturedErrors[0]!.statusMessage).toEqual('Bad Request');
+        expect(capturedErrors[0]!.message).toEqual('Bad Request');
     });
 
     it('should allow error handler to transform the error', async () => {
         const router = new Router();
 
         router.use(defineCoreHandler(() => {
-            throw new RoutupError({ status: 422, statusMessage: 'Unprocessable' });
+            throw new RoutupError({ status: 422, message: 'Unprocessable' });
         }));
 
         router.use(defineErrorHandler(() => {
-            throw new RoutupError({ status: 503, statusMessage: 'Service Unavailable' });
+            throw new RoutupError({ status: 503, message: 'Service Unavailable' });
         }));
 
         const response = await router.fetch(createTestRequest('/'));
@@ -70,7 +70,7 @@ describe('error context preservation', () => {
         const router = new Router();
 
         router.use(defineCoreHandler(() => {
-            throw new RoutupError({ status: 404, statusMessage: 'Not Found' });
+            throw new RoutupError({ status: 404, message: 'Not Found' });
         }));
 
         const response = await router.fetch(createTestRequest('/'));

--- a/test/unit/error/chain.spec.ts
+++ b/test/unit/error/chain.spec.ts
@@ -26,7 +26,7 @@ describe('error context preservation', () => {
         const capturedErrors: RoutupError[] = [];
 
         router.use(defineCoreHandler(() => {
-            throw new RoutupError({ statusCode: 400, statusMessage: 'Bad Request' });
+            throw new RoutupError({ status: 400, statusMessage: 'Bad Request' });
         }));
 
         router.on('error', () => {
@@ -45,7 +45,7 @@ describe('error context preservation', () => {
 
         // The original error is preserved — not overwritten by the hook error
         expect(capturedErrors.length).toBeGreaterThan(0);
-        expect(capturedErrors[0]!.statusCode).toEqual(400);
+        expect(capturedErrors[0]!.status).toEqual(400);
         expect(capturedErrors[0]!.statusMessage).toEqual('Bad Request');
     });
 
@@ -53,11 +53,11 @@ describe('error context preservation', () => {
         const router = new Router();
 
         router.use(defineCoreHandler(() => {
-            throw new RoutupError({ statusCode: 422, statusMessage: 'Unprocessable' });
+            throw new RoutupError({ status: 422, statusMessage: 'Unprocessable' });
         }));
 
         router.use(defineErrorHandler(() => {
-            throw new RoutupError({ statusCode: 503, statusMessage: 'Service Unavailable' });
+            throw new RoutupError({ status: 503, statusMessage: 'Service Unavailable' });
         }));
 
         const response = await router.fetch(createTestRequest('/'));
@@ -70,7 +70,7 @@ describe('error context preservation', () => {
         const router = new Router();
 
         router.use(defineCoreHandler(() => {
-            throw new RoutupError({ statusCode: 404, statusMessage: 'Not Found' });
+            throw new RoutupError({ status: 404, statusMessage: 'Not Found' });
         }));
 
         const response = await router.fetch(createTestRequest('/'));

--- a/test/unit/error/create.spec.ts
+++ b/test/unit/error/create.spec.ts
@@ -17,10 +17,10 @@ describe('src/error/create', () => {
     it('should create error by options', () => {
         const error = createError({
             status: 510,
-            statusMessage: 'foo',
+            message: 'foo',
         });
         expect(error.status).toEqual(510);
-        expect(error.statusMessage).toEqual('foo');
+        expect(error.message).toEqual('foo');
     });
 
     it('should create error for client error', () => {
@@ -29,7 +29,7 @@ describe('src/error/create', () => {
 
         expect(error).toBeDefined();
         expect(error.status).toEqual(notFoundError.status);
-        expect(error.statusMessage).toEqual(notFoundError.statusMessage);
+        expect(error.message).toEqual(notFoundError.message);
     });
 
     it('should create error for server error', () => {
@@ -38,6 +38,6 @@ describe('src/error/create', () => {
 
         expect(error).toBeDefined();
         expect(error.status).toEqual(internalServerError.status);
-        expect(error.statusMessage).toEqual(internalServerError.statusMessage);
+        expect(error.message).toEqual(internalServerError.message);
     });
 });

--- a/test/unit/error/create.spec.ts
+++ b/test/unit/error/create.spec.ts
@@ -16,10 +16,10 @@ describe('src/error/create', () => {
 
     it('should create error by options', () => {
         const error = createError({
-            statusCode: 510,
-            statusMessage: 'foo', 
+            status: 510,
+            statusMessage: 'foo',
         });
-        expect(error.statusCode).toEqual(510);
+        expect(error.status).toEqual(510);
         expect(error.statusMessage).toEqual('foo');
     });
 
@@ -28,7 +28,7 @@ describe('src/error/create', () => {
         const error = createError(notFoundError);
 
         expect(error).toBeDefined();
-        expect(error.statusCode).toEqual(notFoundError.statusCode);
+        expect(error.status).toEqual(notFoundError.status);
         expect(error.statusMessage).toEqual(notFoundError.statusMessage);
     });
 
@@ -37,7 +37,7 @@ describe('src/error/create', () => {
         const error = createError(internalServerError);
 
         expect(error).toBeDefined();
-        expect(error.statusCode).toEqual(internalServerError.statusCode);
+        expect(error.status).toEqual(internalServerError.status);
         expect(error.statusMessage).toEqual(internalServerError.statusMessage);
     });
 });

--- a/test/unit/response/send-stream.spec.ts
+++ b/test/unit/response/send-stream.spec.ts
@@ -28,7 +28,6 @@ describe('src/response/helpers/send-stream', () => {
 
         router.get('/', defineCoreHandler((event) => {
             event.response.status = 206;
-            event.response.statusText = 'Partial Content';
             event.response.headers.set('x-custom', 'stream-header');
 
             const stream = new ReadableStream({

--- a/test/unit/response/to-response.spec.ts
+++ b/test/unit/response/to-response.spec.ts
@@ -20,10 +20,8 @@ describe('src/response/to-response', () => {
     it('should return custom status for null when set', async () => {
         const event = createTestEvent('/');
         event.response.status = 204;
-        event.response.statusText = 'No Content';
         const result = await toResponse(null, event);
         expect(result!.status).toBe(204);
-        expect(result!.statusText).toBe('No Content');
     });
 
     it('should pass through Response as-is', async () => {

--- a/test/unit/response/to-response.spec.ts
+++ b/test/unit/response/to-response.spec.ts
@@ -131,7 +131,7 @@ describe('src/response/to-response', () => {
             await toResponse(circular, event);
             expect.unreachable('should have thrown');
         } catch (e: any) {
-            expect(e.statusCode).toBe(500);
+            expect(e.status).toBe(500);
             expect(e.message).toBe('JSON serialization failed');
             expect(e.cause).toBeInstanceOf(TypeError);
         }


### PR DESCRIPTION
closes #853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Updated @ebec/http dependency version.

* **Bug Fixes**
  * Standardized error objects to use status and message fields.
  * Timeout errors now return HTTP 408.
  * Responses no longer include custom reason phrases/status text.

* **Tests**
  * Updated unit tests to align with revised error and response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->