### PR TITLE
feat(handler): redefine undefined-return contract

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -84,11 +84,17 @@ Handlers return values directly instead of calling `send()`. The `toResponse()` 
 - **Blob** → `Response` with blob's content type
 - **Response** → passed through as-is
 - **null** → empty `Response` (status from `event.response`)
-- **undefined** → no response (middleware pass-through; pipeline continues)
+
+### Returning `undefined`
+
+`undefined` is **not** treated as an implicit pass-through. A handler that returns `undefined` is making a contract: it must have either called `event.next()` (forwarding the downstream result) or it must intend `event.next()` to be invoked later from an async callback.
+
+- **`undefined` after `event.next()` was called** → the captured downstream result becomes the response (so `event.next()` and `return event.next()` are equivalent).
+- **`undefined` before `event.next()` is called** → the handler is considered unresolved. The pipeline waits until either `event.next()` is invoked (e.g. from a `setTimeout` or other async callback) or `event.signal` aborts. A global or per-handler `timeout` surfaces as a `408 Request Timeout`. With no timeout configured and no eventual `event.next()` call, the request hangs by design — bugs become loud (deadlock) rather than silent (404 / wrong body).
 
 ### Middleware and `event.next()`
 
-Middleware handlers call `event.next()` to continue the pipeline (onion model):
+Middleware handlers call `event.next()` to continue the pipeline (onion model). Always `return` (or `await` and re-return) the result so the response propagates:
 
 ```typescript
 defineCoreHandler(async (event) => {
@@ -96,6 +102,15 @@ defineCoreHandler(async (event) => {
     const response = await event.next();
     // After
     return response;
+});
+```
+
+A side-effect middleware that just forwards downstream:
+
+```typescript
+defineCoreHandler((event) => {
+    event.response.headers.set('x-trace', '...');
+    return event.next();
 });
 ```
 

--- a/docs/src/guide/handlers.md
+++ b/docs/src/guide/handlers.md
@@ -46,10 +46,14 @@ defineCoreHandler(() => new Blob(['data']));
 
 // null — empty response
 defineCoreHandler(() => null);
-
-// undefined — middleware pass-through (pipeline continues)
-defineCoreHandler(() => undefined);
 ```
+
+### Returning `undefined`
+
+`undefined` is **not** an implicit pass-through. A handler that returns `undefined` is making a contract: it must have either called `event.next()` (forwarding the downstream result) or it must intend `event.next()` to be invoked later from an async callback.
+
+- Returning `undefined` after calling `event.next()` forwards the downstream result — `event.next()` and `return event.next()` are equivalent in outcome.
+- Returning `undefined` without ever calling `event.next()` leaves the handler unresolved. The pipeline waits until either `event.next()` is invoked or `event.signal` aborts. With a global or per-handler `timeout`, this surfaces as `408 Request Timeout`. With no timeout configured, the request hangs by design — bugs become loud (deadlock) rather than silent (404 / wrong body).
 
 ## Middleware
 

--- a/docs/src/guide/migration-v5.md
+++ b/docs/src/guide/migration-v5.md
@@ -80,7 +80,8 @@ Handlers can return any of these values — `toResponse()` converts them automat
 | `ArrayBuffer` / `Uint8Array` | Binary response |
 | `Blob` | Response with blob's content-type |
 | `null` | Empty response |
-| `undefined` | No response (middleware pass-through; pipeline continues) |
+
+`undefined` is **not** an implicit pass-through: a handler that returns `undefined` must call `event.next()` (now or from a later async callback) — otherwise the pipeline waits on `event.signal` and a configured `timeout` surfaces as `408`. See [Handlers → Returning `undefined`](./handlers.md#returning-undefined).
 
 To set custom status or headers without constructing a full `Response`:
 

--- a/docs/src/guide/response.md
+++ b/docs/src/guide/response.md
@@ -25,10 +25,13 @@ defineCoreHandler(() => new ArrayBuffer(8));
 
 // null — empty response
 defineCoreHandler(() => null);
-
-// undefined — middleware pass-through (pipeline continues)
-defineCoreHandler(() => undefined);
 ```
+
+### Returning `undefined`
+
+`undefined` is **not** an implicit pass-through. A handler that returns `undefined` must have either called `event.next()` (forwarding the downstream result) or intend `event.next()` to be invoked later from an async callback.
+
+If `event.next()` is never invoked, the pipeline waits on `event.signal`: a global or per-handler `timeout` surfaces as `408 Request Timeout`; with no timeout configured the request hangs by design. See [Handlers → Returning `undefined`](./handlers.md#returning-undefined) for details.
 
 ## Status and Headers
 

--- a/src/event/module.ts
+++ b/src/event/module.ts
@@ -45,6 +45,15 @@ export class RoutupEvent implements IRoutupEvent {
 
     protected _routerOptions?: RouterOptions;
 
+    protected _nextCalled = false;
+
+    protected _nextResult: Promise<Response | undefined> | undefined;
+
+    protected _nextCalledDeferred: {
+        promise: Promise<void>,
+        resolve: () => void,
+    } | undefined;
+
     constructor(context: RoutupEventCreateContext) {
         this._context = context;
         this.request = context.request;
@@ -67,7 +76,40 @@ export class RoutupEvent implements IRoutupEvent {
         return this._routerOptions;
     }
 
+    get nextCalled(): boolean {
+        return this._nextCalled;
+    }
+
+    get nextResult(): Promise<Response | undefined> | undefined {
+        return this._nextResult;
+    }
+
+    whenNextCalled(): Promise<void> {
+        if (!this._nextCalledDeferred) {
+            let resolve!: () => void;
+            const promise = new Promise<void>((r) => { resolve = r; });
+            this._nextCalledDeferred = { promise, resolve };
+
+            if (this._nextCalled) {
+                resolve();
+            }
+        }
+
+        return this._nextCalledDeferred.promise;
+    }
+
     async next(error?: Error): Promise<Response | undefined> {
-        return this._context.next(this, error);
+        if (this._nextCalled) {
+            return this._nextResult;
+        }
+
+        this._nextCalled = true;
+        this._nextResult = this._context.next(this, error);
+
+        if (this._nextCalledDeferred) {
+            this._nextCalledDeferred.resolve();
+        }
+
+        return this._nextResult;
     }
 }

--- a/src/event/types.ts
+++ b/src/event/types.ts
@@ -88,4 +88,30 @@ export interface IRoutupEvent {
      * Returns the downstream `Response`, or `undefined` if no handler matched.
      */
     next(error?: Error): Promise<Response | undefined>;
+
+    /**
+     * Whether `next()` has been invoked on this event.
+     *
+     * Used by the dispatch pipeline to disambiguate an `undefined` return value:
+     * a handler that returns `undefined` after calling `next()` is forwarding the
+     * downstream result; one that returns `undefined` without calling `next()` is
+     * unresolved and will wait on `signal` (timeout-bounded).
+     */
+    readonly nextCalled: boolean;
+
+    /**
+     * The cached promise returned by the first `next()` call on this event,
+     * or `undefined` if `next()` has not been invoked.
+     */
+    readonly nextResult: Promise<Response | undefined> | undefined;
+
+    /**
+     * Returns a promise that resolves the first time `next()` is invoked on this event.
+     *
+     * If `next()` has already been called, the returned promise is already resolved.
+     * Used by the dispatch pipeline so a handler that returns `undefined` and later
+     * calls `next()` asynchronously (e.g. from a `setTimeout`) still propagates the
+     * downstream response instead of hanging until `signal` aborts.
+     */
+    whenNextCalled(): Promise<void>;
 }

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -1,6 +1,7 @@
 import { MethodName } from '../constants.ts';
 import type { IDispatcher, IDispatcherEvent } from '../dispatcher/index.ts';
 import { createError, isError } from '../error/index.ts';
+import type { IRoutupEvent } from '../event/index.ts';
 import { HookManager, HookName } from '../hook/index.ts';
 import type { Path } from '../path/index.ts';
 import { PathMatcher } from '../path/index.ts';
@@ -105,7 +106,10 @@ export class Handler implements IDispatcher {
                         const { fn } = this.config;
                         const { error } = event;
                         result = await this.executeWithTimeout(
-                            () => fn(error, handlerEvent),
+                            () => this.resolveHandlerResult(
+                                fn(error, handlerEvent),
+                                handlerEvent,
+                            ),
                             handlerEvent.routerOptions,
                             childController,
                         );
@@ -113,7 +117,10 @@ export class Handler implements IDispatcher {
                 } else {
                     const { fn } = this.config;
                     result = await this.executeWithTimeout(
-                        () => fn(handlerEvent),
+                        () => this.resolveHandlerResult(
+                            fn(handlerEvent),
+                            handlerEvent,
+                        ),
                         handlerEvent.routerOptions,
                         childController,
                     );
@@ -190,6 +197,54 @@ export class Handler implements IDispatcher {
     }
 
     // --------------------------------------------------
+
+    /**
+     * Resolve a handler's return value into the final value handed to `toResponse`.
+     *
+     * Contract:
+     * - non-undefined value → return as-is (becomes the response)
+     * - `undefined` + `event.next()` was called → forward downstream result
+     * - `undefined` + `event.next()` not yet called → wait until either `next()` is
+     *   invoked (e.g. from an async callback) or `signal` aborts. A global or
+     *   per-handler timeout aborts `signal` and surfaces as 408. With no timeout
+     *   configured and no eventual `next()` call, the request hangs by design.
+     */
+    protected async resolveHandlerResult(
+        invocation: unknown | Promise<unknown>,
+        handlerEvent: IRoutupEvent,
+    ): Promise<unknown> {
+        const value = await invocation;
+        if (typeof value !== 'undefined') {
+            return value;
+        }
+
+        if (handlerEvent.nextCalled) {
+            return handlerEvent.nextResult;
+        }
+
+        const { signal } = handlerEvent;
+
+        if (signal.aborted) {
+            throw createError({ status: 408, message: 'Request Timeout' });
+        }
+
+        return new Promise<unknown>((resolve, reject) => {
+            const onAbort = () => {
+                signal.removeEventListener('abort', onAbort);
+                reject(createError({
+                    status: 408,
+                    message: 'Request Timeout',
+                }));
+            };
+
+            signal.addEventListener('abort', onAbort, { once: true });
+
+            handlerEvent.whenNextCalled().then(() => {
+                signal.removeEventListener('abort', onAbort);
+                resolve(handlerEvent.nextResult);
+            });
+        });
+    }
 
     protected async executeWithTimeout(
         fn: () => unknown | Promise<unknown>,

--- a/test/unit/routing/undefined-return.spec.ts
+++ b/test/unit/routing/undefined-return.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+    Router,
+    defineCoreHandler,
+} from '../../../src';
+import { createTestRequest } from '../../helpers';
+
+describe('routing/undefined-return', () => {
+    it('forwards downstream response when handler calls event.next() without returning it', async () => {
+        const router = new Router();
+
+        router.use(defineCoreHandler(async (event) => {
+            event.response.headers.set('x-trace', 'mw');
+            await event.next();
+            // intentional: handler returns undefined but called next()
+        }));
+
+        router.get(defineCoreHandler(() => 'inner'));
+
+        const response = await router.fetch(createTestRequest('/'));
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe('inner');
+        expect(response.headers.get('x-trace')).toBe('mw');
+    });
+
+    it('treats explicit null as an empty response (does not hang)', async () => {
+        const router = new Router({ timeout: 100 });
+
+        router.get(defineCoreHandler((event) => {
+            event.response.status = 204;
+            return null;
+        }));
+
+        const response = await router.fetch(createTestRequest('/'));
+
+        expect(response.status).toBe(204);
+        expect(await response.text()).toBe('');
+    });
+
+    it('hangs until global timeout when handler returns undefined and does not call next()', async () => {
+        const router = new Router({ timeout: 50 });
+
+        router.get(defineCoreHandler((event) => {
+            event.response.headers.set('x-touched', '1');
+            // intentional: no return, no event.next()
+        }));
+
+        const response = await router.fetch(createTestRequest('/'));
+
+        expect(response.status).toBe(408);
+    });
+
+    it('hangs until per-handler timeout when handler returns undefined and does not call next()', async () => {
+        const router = new Router({ handlerTimeout: 50 });
+
+        router.get(defineCoreHandler(() => {
+            // intentional: no return, no event.next()
+        }));
+
+        const response = await router.fetch(createTestRequest('/'));
+
+        expect(response.status).toBe(408);
+    });
+
+    it('resumes when event.next() is called asynchronously after handler returns undefined', async () => {
+        const router = new Router({ timeout: 500 });
+
+        router.use(defineCoreHandler((event) => {
+            setTimeout(() => {
+                void event.next();
+            }, 20);
+            // intentional: returns undefined; next() is called later
+        }));
+
+        router.get(defineCoreHandler(() => 'late'));
+
+        const response = await router.fetch(createTestRequest('/'));
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe('late');
+    });
+
+    it('aborts event.signal when undefined-return hangs and timeout fires', async () => {
+        const router = new Router({ timeout: 50 });
+        let aborted = false;
+
+        router.get(defineCoreHandler((event) => {
+            event.signal.addEventListener('abort', () => {
+                aborted = true;
+            });
+            // intentional: no return, no event.next()
+        }));
+
+        await router.fetch(createTestRequest('/'));
+
+        expect(aborted).toBe(true);
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Handlers returning `undefined` without invoking the pipeline will timeout to HTTP 408 instead of acting as implicit middleware pass-through.

* **Documentation**
  * Clarified handler return semantics and pipeline behavior for `undefined` returns.
  * Updated migration guide with detailed response model information.
  * Added middleware examples demonstrating proper handler propagation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->