### PR TITLE
refactor(router): move mount path off the user-held router onto stack…

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -7,3 +7,4 @@ export * from './is.ts';
 export * from './module.ts';
 export * from './types.ts';
 export * from './types-base.ts';
+export * from './utils.ts';

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -3,13 +3,13 @@ import type { IDispatcher, IDispatcherEvent } from '../dispatcher/index.ts';
 import { createError, isError } from '../error/index.ts';
 import type { IRoutupEvent } from '../event/index.ts';
 import { HookManager, HookName } from '../hook/index.ts';
-import type { Path } from '../path/index.ts';
-import { PathMatcher } from '../path/index.ts';
+import type { PathMatcher } from '../path/index.ts';
 import { toResponse } from '../response/index.ts';
 import type { RouterOptions } from '../router/types.ts';
 import { toMethodName, withLeadingSlash } from '../utils/index.ts';
 import { HandlerSymbol, HandlerType } from './constants.ts';
 import type { HandlerOptions } from './types.ts';
+import { buildHandlerPathMatcher } from './utils.ts';
 
 export class Handler implements IDispatcher {
     readonly '@instanceof' = HandlerSymbol;
@@ -29,7 +29,12 @@ export class Handler implements IDispatcher {
         this.hookManager = new HookManager();
 
         this.mountHooks();
-        this.setPath(handler.path);
+
+        if (typeof handler.path === 'string') {
+            this.config.path = withLeadingSlash(handler.path);
+        }
+
+        this.pathMatcher = buildHandlerPathMatcher(this.config.path, !!this.config.method);
     }
 
     // --------------------------------------------------
@@ -161,21 +166,6 @@ export class Handler implements IDispatcher {
         }
 
         return this.pathMatcher.test(path);
-    }
-
-    setPath(path?: Path): void {
-        if (typeof path === 'string') {
-            path = withLeadingSlash(path);
-        }
-
-        this.config.path = path;
-
-        if (typeof path === 'undefined') {
-            this.pathMatcher = undefined;
-            return;
-        }
-
-        this.pathMatcher = new PathMatcher(path, { end: !!this.config.method });
     }
 
     // --------------------------------------------------

--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -1,4 +1,4 @@
-import { MethodName } from '../constants.ts';
+import type { MethodName } from '../constants.ts';
 import type { IDispatcher, IDispatcherEvent } from '../dispatcher/index.ts';
 import { createError, isError } from '../error/index.ts';
 import type { IRoutupEvent } from '../event/index.ts';
@@ -20,7 +20,7 @@ export class Handler implements IDispatcher {
 
     protected pathMatcher: PathMatcher | undefined;
 
-    protected _method: MethodName | undefined;
+    readonly method: MethodName | undefined;
 
     // --------------------------------------------------
 
@@ -35,6 +35,7 @@ export class Handler implements IDispatcher {
         }
 
         this.pathMatcher = buildHandlerPathMatcher(this.config.path, !!this.config.method);
+        this.method = this.config.method ? toMethodName(this.config.method) : undefined;
     }
 
     // --------------------------------------------------
@@ -45,15 +46,6 @@ export class Handler implements IDispatcher {
 
     get path() {
         return this.config.path;
-    }
-
-    get method() {
-        if (this._method || !this.config.method) {
-            return this._method;
-        }
-
-        this._method = toMethodName(this.config.method);
-        return this._method;
     }
 
     // --------------------------------------------------
@@ -166,24 +158,6 @@ export class Handler implements IDispatcher {
         }
 
         return this.pathMatcher.test(path);
-    }
-
-    // --------------------------------------------------
-
-    matchMethod(method: MethodName): boolean {
-        return !this.method ||
-            method === this.method ||
-            (
-                method === MethodName.HEAD &&
-                this.method === MethodName.GET
-            );
-    }
-
-    setMethod(input?: MethodName): void {
-        const method = toMethodName(input);
-
-        this.config.method = method;
-        this._method = method;
     }
 
     // --------------------------------------------------

--- a/src/handler/utils.ts
+++ b/src/handler/utils.ts
@@ -1,0 +1,22 @@
+import { PathMatcher } from '../path/index.ts';
+import type { Path } from '../path/index.ts';
+import { withLeadingSlash } from '../utils/index.ts';
+
+/**
+ * Build a `PathMatcher` for a handler-side path.
+ *
+ * Returns `undefined` when no path is supplied. The `end` flag controls
+ * whether the matcher requires a full match (`true` for method handlers
+ * matching exact routes) or accepts a prefix (`false` for middleware).
+ */
+export function buildHandlerPathMatcher(
+    path: Path | undefined,
+    end: boolean,
+): PathMatcher | undefined {
+    if (typeof path === 'undefined') {
+        return undefined;
+    }
+
+    const normalized = typeof path === 'string' ? withLeadingSlash(path) : path;
+    return new PathMatcher(normalized, { end });
+}

--- a/src/handler/utils.ts
+++ b/src/handler/utils.ts
@@ -1,3 +1,4 @@
+import { MethodName } from '../constants.ts';
 import { PathMatcher } from '../path/index.ts';
 import type { Path } from '../path/index.ts';
 import { withLeadingSlash } from '../utils/index.ts';
@@ -19,4 +20,20 @@ export function buildHandlerPathMatcher(
 
     const normalized = typeof path === 'string' ? withLeadingSlash(path) : path;
     return new PathMatcher(normalized, { end });
+}
+
+/**
+ * Match a request method against a handler's bound method.
+ *
+ * - When the handler has no method bound, matches every request method.
+ * - Otherwise matches when the request method is the same.
+ * - HEAD requests additionally match GET handlers.
+ */
+export function matchHandlerMethod(
+    handlerMethod: MethodName | undefined,
+    requestMethod: MethodName,
+): boolean {
+    return !handlerMethod ||
+        requestMethod === handlerMethod ||
+        (requestMethod === MethodName.HEAD && handlerMethod === MethodName.GET);
 }

--- a/src/router/module.ts
+++ b/src/router/module.ts
@@ -10,6 +10,7 @@ import {
     buildHandlerPathMatcher,
     isHandler,
     isHandlerOptions,
+    matchHandlerMethod,
 } from '../handler/index.ts';
 import type {
     HookDefaultListener,
@@ -236,11 +237,13 @@ export class Router implements IRouter {
                     handler.matchPath(context.event.path);
 
                 if (match) {
-                    if (handler.method) {
-                        context.event.methodsAllowed.add(handler.method);
+                    const method = entry.method ?? handler.method;
+
+                    if (method) {
+                        context.event.methodsAllowed.add(method);
                     }
 
-                    if (handler.matchMethod(context.event.method as MethodName)) {
+                    if (matchHandlerMethod(method, context.event.method as MethodName)) {
                         await this.hookManager.trigger(HookName.CHILD_MATCH, context.event);
 
                         if (context.event.dispatched) {
@@ -534,27 +537,27 @@ export class Router implements IRouter {
                 continue;
             }
 
+            let handler: Handler;
             if (isHandlerOptions(element)) {
-                if (path) {
-                    element.path = path;
-                }
-
-                element.method = method;
-
-                this.use(element);
-
+                // Construct a fresh Handler from a copy of the options so the
+                // user's options object is never mutated.
+                handler = new Handler({
+                    ...element,
+                    method,
+                    path: path ?? element.path,
+                });
+            } else if (isHandler(element)) {
+                handler = element;
+            } else {
                 continue;
             }
 
-            if (isHandler(element)) {
-                element.setMethod(method);
-
-                if (path) {
-                    this.use(path, element);
-                } else {
-                    this.use(element);
-                }
-            }
+            this.stack.push({
+                type: RouterStackEntryType.HANDLER,
+                data: handler,
+                method,
+                pathMatcher: buildHandlerPathMatcher(path ?? handler.path, true),
+            });
         }
     }
 
@@ -590,11 +593,14 @@ export class Router implements IRouter {
             }
 
             if (isHandlerOptions(item)) {
-                item.path = path || item.path;
+                const handler = new Handler({
+                    ...item,
+                    path: path ?? item.path,
+                });
 
                 this.stack.push({
                     type: RouterStackEntryType.HANDLER,
-                    data: new Handler(item),
+                    data: handler,
                 });
                 continue;
             }

--- a/src/router/module.ts
+++ b/src/router/module.ts
@@ -7,6 +7,7 @@ import {
     Handler,
     type HandlerOptions,
     HandlerType,
+    buildHandlerPathMatcher,
     isHandler,
     isHandlerOptions,
 } from '../handler/index.ts';
@@ -89,8 +90,7 @@ export class Router implements IRouter {
 
         this.hookManager = new HookManager();
         this._options = normalizeRouterOptions(input);
-
-        this.setPath(input.path);
+        this.pathMatcher = buildRouterPathMatcher(input.path);
     }
 
     // --------------------------------------------------
@@ -101,10 +101,6 @@ export class Router implements IRouter {
         }
 
         return true;
-    }
-
-    setPath(value?: Path) {
-        this.pathMatcher = buildRouterPathMatcher(value);
     }
 
     // --------------------------------------------------
@@ -235,7 +231,9 @@ export class Router implements IRouter {
                     continue;
                 }
 
-                const match = handler.matchPath(context.event.path);
+                const match = entry.pathMatcher ?
+                    entry.pathMatcher.test(context.event.path) :
+                    handler.matchPath(context.event.path);
 
                 if (match) {
                     if (handler.method) {
@@ -312,10 +310,10 @@ export class Router implements IRouter {
         const { event } = context;
 
         if (entry.type === RouterStackEntryType.ROUTER && entry.pathMatcher) {
-            // Apply the mount-specific matcher; strip the matched prefix off
-            // event.path so the child router's pipeline sees a mount-relative
-            // path. The child router's intrinsic pathMatcher (if any) is
-            // applied on top inside its own dispatch.
+            // Router mount: strip the matched prefix off event.path so the
+            // child router's pipeline sees a mount-relative path. The child
+            // router's intrinsic pathMatcher (if any) is applied on top
+            // inside its own dispatch.
             const output = entry.pathMatcher.exec(event.path);
             if (typeof output !== 'undefined') {
                 event.mountPath = cleanDoubleSlashes(`${event.mountPath}/${output.path}`);
@@ -326,6 +324,16 @@ export class Router implements IRouter {
                     event.path = withLeadingSlash(event.path.substring(output.path.length));
                 }
 
+                event.params = {
+                    ...event.params,
+                    ...output.params,
+                };
+            }
+        } else if (entry.type === RouterStackEntryType.HANDLER && entry.pathMatcher) {
+            // Handler mount: extract route params from the mount matcher.
+            // Handlers don't strip the path — they're leaves.
+            const output = entry.pathMatcher.exec(event.path);
+            if (typeof output !== 'undefined') {
                 event.params = {
                     ...event.params,
                     ...output.params,
@@ -539,13 +547,13 @@ export class Router implements IRouter {
             }
 
             if (isHandler(element)) {
-                if (path) {
-                    element.setPath(path);
-                }
-
                 element.setMethod(method);
 
-                this.use(element);
+                if (path) {
+                    this.use(path, element);
+                } else {
+                    this.use(element);
+                }
             }
         }
     }
@@ -592,9 +600,11 @@ export class Router implements IRouter {
             }
 
             if (isHandler(item)) {
-                item.setPath(path || item.path);
-
-                this.stack.push({ type: RouterStackEntryType.HANDLER, data: item });
+                this.stack.push({
+                    type: RouterStackEntryType.HANDLER,
+                    data: item,
+                    pathMatcher: buildHandlerPathMatcher(path, !!item.method),
+                });
                 continue;
             }
 

--- a/src/router/module.ts
+++ b/src/router/module.ts
@@ -17,8 +17,8 @@ import type {
     HookUnsubscribeFn,
 } from '../hook/index.ts';
 import { HookManager, HookName } from '../hook/index.ts';
-import type { Path } from '../path/index.ts';
-import { PathMatcher, isPath } from '../path/index.ts';
+import type { Path, PathMatcher } from '../path/index.ts';
+import { isPath } from '../path/index.ts';
 import type { Plugin, PluginInstallContext } from '../plugin/index.ts';
 import {
     PluginAlreadyInstalledError,
@@ -28,7 +28,6 @@ import { normalizeRouterOptions } from './options.ts';
 import {
     cleanDoubleSlashes,
     withLeadingSlash,
-    withoutTrailingSlash,
 } from '../utils/index.ts';
 import { RouterPipelineStep, RouterStackEntryType, RouterSymbol } from './constants.ts';
 import type {
@@ -38,7 +37,7 @@ import type {
     RouterPipelineContext,
     StackEntry,
 } from './types.ts';
-import { acceptsJson, isRouterInstance } from './utils.ts';
+import { acceptsJson, buildRouterPathMatcher, isRouterInstance } from './utils.ts';
 
 export class Router implements IRouter {
     readonly '@instanceof' = RouterSymbol;
@@ -105,15 +104,7 @@ export class Router implements IRouter {
     }
 
     setPath(value?: Path) {
-        if (value === '/' || typeof value === 'undefined') {
-            this.pathMatcher = undefined;
-            return;
-        }
-
-        this.pathMatcher = new PathMatcher(
-            withLeadingSlash(withoutTrailingSlash(`${value}`)),
-            { end: false },
-        );
+        this.pathMatcher = buildRouterPathMatcher(value);
     }
 
     // --------------------------------------------------
@@ -268,7 +259,9 @@ export class Router implements IRouter {
                 continue;
             }
 
-            const match = entry.data.matchPath(context.event.path);
+            const match = entry.pathMatcher ?
+                entry.pathMatcher.test(context.event.path) :
+                entry.data.matchPath(context.event.path);
 
             if (match) {
                 await this.hookManager.trigger(HookName.CHILD_MATCH, context.event);
@@ -317,6 +310,28 @@ export class Router implements IRouter {
         }
 
         const { event } = context;
+
+        if (entry.type === RouterStackEntryType.ROUTER && entry.pathMatcher) {
+            // Apply the mount-specific matcher; strip the matched prefix off
+            // event.path so the child router's pipeline sees a mount-relative
+            // path. The child router's intrinsic pathMatcher (if any) is
+            // applied on top inside its own dispatch.
+            const output = entry.pathMatcher.exec(event.path);
+            if (typeof output !== 'undefined') {
+                event.mountPath = cleanDoubleSlashes(`${event.mountPath}/${output.path}`);
+
+                if (event.path === output.path) {
+                    event.path = '/';
+                } else {
+                    event.path = withLeadingSlash(event.path.substring(output.path.length));
+                }
+
+                event.params = {
+                    ...event.params,
+                    ...output.params,
+                };
+            }
+        }
 
         try {
             event.setNext(async (error?: Error) => {
@@ -558,10 +573,11 @@ export class Router implements IRouter {
             }
 
             if (isRouterInstance(item)) {
-                if (path) {
-                    item.setPath(path);
-                }
-                this.stack.push({ type: RouterStackEntryType.ROUTER, data: item });
+                this.stack.push({
+                    type: RouterStackEntryType.ROUTER,
+                    data: item,
+                    pathMatcher: buildRouterPathMatcher(path),
+                });
                 continue;
             }
 

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -1,3 +1,4 @@
+import type { MethodName } from '../constants.ts';
 import type { IDispatcher, IDispatcherEvent } from '../dispatcher/index.ts';
 import type { RoutupRequest } from '../event/index.ts';
 import type {
@@ -101,6 +102,14 @@ export type StackHandlerEntry = {
      * to the handler's own intrinsic matcher.
      */
     pathMatcher?: PathMatcher,
+    /**
+     * Mount-specific HTTP method.
+     *
+     * Set when the handler was registered via a method-bound shortcut
+     * (e.g. `router.get(handler)` sets this to `GET`). When undefined,
+     * dispatch falls back to the handler's own intrinsic method.
+     */
+    method?: MethodName,
 };
 
 export type StackEntry = StackRouterEntry | StackHandlerEntry;

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -12,7 +12,7 @@ import type {
     HookUnsubscribeFn,
 } from '../hook/index.ts';
 
-import type { Path } from '../path/index.ts';
+import type { Path, PathMatcher } from '../path/index.ts';
 import type { Plugin } from '../plugin/index.ts';
 import type {
     EtagFn,
@@ -81,6 +81,13 @@ export type RouterPathNode = {
 export type StackRouterEntry = {
     type: typeof RouterStackEntryType.ROUTER,
     data: IRouter,
+    /**
+     * Mount-specific path matcher.
+     *
+     * Set when the router was mounted under a path (e.g. `parent.use('/api', child)`).
+     * When undefined, the lookup falls back to the router's own intrinsic matcher.
+     */
+    pathMatcher?: PathMatcher,
 };
 
 export type StackHandlerEntry = {

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -93,6 +93,14 @@ export type StackRouterEntry = {
 export type StackHandlerEntry = {
     type: typeof RouterStackEntryType.HANDLER,
     data: Handler,
+    /**
+     * Mount-specific path matcher.
+     *
+     * Set when the handler was registered under a path (e.g.
+     * `parent.use('/api', handler)`). When undefined, the lookup falls back
+     * to the handler's own intrinsic matcher.
+     */
+    pathMatcher?: PathMatcher,
 };
 
 export type StackEntry = StackRouterEntry | StackHandlerEntry;
@@ -124,11 +132,6 @@ export interface IRouter extends IDispatcher {
      * Test if a path matches this router's mount path.
      */
     matchPath(path: string): boolean;
-
-    /**
-     * Set or clear the router's mount path.
-     */
-    setPath(value?: Path): void;
 
     /**
      * Check if a plugin with the given name is installed on this router.

--- a/src/router/utils.ts
+++ b/src/router/utils.ts
@@ -1,9 +1,28 @@
-import { isInstance } from '../utils/index.ts';
+import type { Path } from '../path/index.ts';
+import { PathMatcher } from '../path/index.ts';
+import { isInstance, withLeadingSlash, withoutTrailingSlash } from '../utils/index.ts';
 import { RouterSymbol } from './constants.ts';
 import type { Router } from './module.ts';
 
 export function isRouterInstance(input: unknown): input is Router {
     return isInstance(input, RouterSymbol);
+}
+
+/**
+ * Build a non-terminal `PathMatcher` for a router mount path.
+ *
+ * Returns `undefined` when the path is the root (`/`) or omitted entirely —
+ * a router mounted at the root has no intrinsic path filter.
+ */
+export function buildRouterPathMatcher(value?: Path): PathMatcher | undefined {
+    if (value === '/' || typeof value === 'undefined') {
+        return undefined;
+    }
+
+    return new PathMatcher(
+        withLeadingSlash(withoutTrailingSlash(`${value}`)),
+        { end: false },
+    );
 }
 
 /**

--- a/test/unit/routing/mounting.spec.ts
+++ b/test/unit/routing/mounting.spec.ts
@@ -51,4 +51,18 @@ describe('src/router mounting', () => {
         const response = await parent.fetch(createTestRequest('/api/ping'));
         expect(await response.text()).toEqual('pong');
     });
+
+    it('should not mutate a handler\'s method when registered via a method shortcut', async () => {
+        const handler = defineCoreHandler(() => 'ok');
+        const before = handler.method;
+
+        const router = new Router();
+        router.get('/foo', handler);
+
+        // Method bound on the entry, not on the handler itself.
+        expect(handler.method).toEqual(before);
+
+        const response = await router.fetch(createTestRequest('/foo'));
+        expect(await response.text()).toEqual('ok');
+    });
 });

--- a/test/unit/routing/mounting.spec.ts
+++ b/test/unit/routing/mounting.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+    Router,
+    defineCoreHandler,
+} from '../../../src';
+import { createTestRequest } from '../../helpers';
+
+describe('src/router mounting', () => {
+    it('should not mutate the user-held child router\'s mount path', async () => {
+        const child = new Router();
+        child.get('/ping', defineCoreHandler(() => 'pong'));
+
+        const parent = new Router();
+        parent.use('/api', child);
+
+        // The mount path lives on the parent's stack entry, not on the child.
+        // Mounting the child elsewhere later should not be affected by the
+        // first mount.
+        const otherParent = new Router();
+        otherParent.use('/v2', child);
+
+        const fromApi = await parent.fetch(createTestRequest('/api/ping'));
+        expect(await fromApi.text()).toEqual('pong');
+
+        const fromV2 = await otherParent.fetch(createTestRequest('/v2/ping'));
+        expect(await fromV2.text()).toEqual('pong');
+    });
+
+    it('should allow mounting the same router twice on the same parent at different paths', async () => {
+        const child = new Router();
+        child.get('/ping', defineCoreHandler(() => 'pong'));
+
+        const parent = new Router();
+        parent.use('/a', child);
+        parent.use('/b', child);
+
+        const fromA = await parent.fetch(createTestRequest('/a/ping'));
+        expect(await fromA.text()).toEqual('pong');
+
+        const fromB = await parent.fetch(createTestRequest('/b/ping'));
+        expect(await fromB.text()).toEqual('pong');
+    });
+
+    it('should fall back to the router\'s own intrinsic path when no mount path is given', async () => {
+        const child = new Router({ path: '/api' });
+        child.get('/ping', defineCoreHandler(() => 'pong'));
+
+        const parent = new Router();
+        parent.use(child);
+
+        const response = await parent.fetch(createTestRequest('/api/ping'));
+        expect(await response.text()).toEqual('pong');
+    });
+});


### PR DESCRIPTION
… entry

Mounting a router via `parent.use(path, child)` previously called `child.setPath(path)`, mutating the user-held child instance. With this change, the mount path lives on the parent's `StackRouterEntry.pathMatcher` instead — the child router is never modified.

- Add `pathMatcher?: PathMatcher` to `StackRouterEntry`.
- Extract the inner of `setPath()` into a `buildRouterPathMatcher(value)` helper that returns `undefined` for the root path or unset values.
- `use()` for routers builds the matcher via the helper and stores it on the stack entry, no longer touching the child's own pathMatcher.
- Lookup prefers `entry.pathMatcher` over the data's intrinsic matcher (`entry.pathMatcher.test(path) ?? entry.data.matchPath(path)`).
- Child-dispatch strips the matched prefix off `event.path` (and merges params/mountPath) when `entry.pathMatcher` is set, before delegating to `entry.data.dispatch(event)`. The child router's own intrinsic pathMatcher (if set in its constructor) still applies on top.

This naturally supports mounting the same router instance on multiple parents at different paths, since the mount state lives on the parent's stack entry rather than on the child.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced router mounting with improved path rewriting and mount-specific matching.
  * Added automatic JSON content negotiation to detect client response preferences.

* **Improvements**
  * Centralized path-matching logic for more consistent routing behavior.
  * Better support for mounting child routers with proper parameter handling.

* **Tests**
  * Added test coverage for router mounting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->