### PR TITLE
feat(router): add Router.clone() for re-mounting under multiple paths

### DIFF
--- a/src/handler/module.ts
+++ b/src/handler/module.ts
@@ -3,7 +3,7 @@ import type { MethodName } from '../constants.ts';
 import type { IDispatcher, IDispatcherEvent } from '../dispatcher/index.ts';
 import { createError, isError } from '../error/index.ts';
 import type { IRoutupEvent } from '../event/index.ts';
-import { HookManager, HookName } from '../hook/index.ts';
+import { HookName, Hooks, type IHooks } from '../hook/index.ts';
 import type { PathMatcher } from '../path/index.ts';
 import { toResponse } from '../response/index.ts';
 import type { RouterOptions } from '../router/types.ts';
@@ -15,7 +15,7 @@ import { buildHandlerPathMatcher } from './utils.ts';
 export class Handler implements IDispatcher {
     protected config: HandlerOptions;
 
-    protected hookManager: HookManager;
+    protected hooks: IHooks;
 
     protected pathMatcher: PathMatcher | undefined;
 
@@ -25,7 +25,7 @@ export class Handler implements IDispatcher {
 
     constructor(handler: HandlerOptions) {
         this.config = handler;
-        this.hookManager = new HookManager();
+        this.hooks = new Hooks();
 
         this.mountHooks();
 
@@ -62,7 +62,7 @@ export class Handler implements IDispatcher {
             }
         }
 
-        await this.hookManager.trigger(HookName.CHILD_DISPATCH_BEFORE, event);
+        await this.hooks.trigger(HookName.CHILD_DISPATCH_BEFORE, event);
         if (event.dispatched) {
             return undefined;
         }
@@ -137,7 +137,7 @@ export class Handler implements IDispatcher {
         } catch (e) {
             event.error = isError(e) ? e : createError(e);
 
-            await this.hookManager.trigger(HookName.ERROR, event);
+            await this.hooks.trigger(HookName.ERROR, event);
 
             if (event.dispatched) {
                 event.error = undefined;
@@ -146,7 +146,7 @@ export class Handler implements IDispatcher {
             }
         }
 
-        await this.hookManager.trigger(HookName.CHILD_DISPATCH_AFTER, event);
+        await this.hooks.trigger(HookName.CHILD_DISPATCH_AFTER, event);
 
         return response;
     }
@@ -269,15 +269,15 @@ export class Handler implements IDispatcher {
 
     protected mountHooks() {
         if (this.config.onBefore) {
-            this.hookManager.addListener(HookName.CHILD_DISPATCH_BEFORE, this.config.onBefore);
+            this.hooks.addListener(HookName.CHILD_DISPATCH_BEFORE, this.config.onBefore);
         }
 
         if (this.config.onAfter) {
-            this.hookManager.addListener(HookName.CHILD_DISPATCH_AFTER, this.config.onAfter);
+            this.hooks.addListener(HookName.CHILD_DISPATCH_AFTER, this.config.onAfter);
         }
 
         if (this.config.onError) {
-            this.hookManager.addListener(HookName.ERROR, this.config.onError);
+            this.hooks.addListener(HookName.ERROR, this.config.onError);
         }
     }
 }

--- a/src/hook/module.ts
+++ b/src/hook/module.ts
@@ -6,6 +6,7 @@ import type {
     HookErrorListener,
     HookListener,
     HookUnsubscribeFn,
+    IHooks,
 } from './types.ts';
 
 type HookEntry = {
@@ -13,7 +14,7 @@ type HookEntry = {
     priority: number;
 };
 
-export class HookManager {
+export class Hooks implements IHooks {
     protected items: Record<string, HookEntry[]>;
 
     // --------------------------------------------------
@@ -69,6 +70,28 @@ export class HookManager {
         if (this.items[name].length === 0) {
             delete this.items[name];
         }
+    }
+
+    // --------------------------------------------------
+
+    /**
+     * Create a new `Hooks` instance seeded with the same listeners as this
+     * one.
+     *
+     * Listener functions are shared by reference; priority and ordering are
+     * preserved. Future mutations on the returned instance do not affect this
+     * one (and vice versa).
+     */
+    clone(): IHooks {
+        const next = new Hooks();
+        const names = Object.keys(this.items);
+        for (const name of names) {
+            const entries = this.items[name]!;
+            for (const entry of entries) {
+                next.addListener(name as HookName, entry.fn, entry.priority);
+            }
+        }
+        return next;
     }
 
     // --------------------------------------------------

--- a/src/hook/types.ts
+++ b/src/hook/types.ts
@@ -1,4 +1,5 @@
 import type { IDispatcherEvent } from '../dispatcher/types.ts';
+import type { HookName } from './constants.ts';
 
 export type HookErrorListener = (event: IDispatcherEvent) => Promise<unknown> | unknown;
 export type HookDefaultListener = (event: IDispatcherEvent) => Promise<unknown> | unknown;
@@ -6,3 +7,24 @@ export type HookDefaultListener = (event: IDispatcherEvent) => Promise<unknown> 
 export type HookListener = HookErrorListener | HookDefaultListener;
 
 export type HookUnsubscribeFn = () => void;
+
+export interface IHooks {
+    addListener(
+        name: HookName,
+        fn: HookListener,
+        priority?: number,
+    ): HookUnsubscribeFn;
+
+    removeListener(name: HookName): void;
+
+    removeListener(name: HookName, fn: HookListener): void;
+
+    removeListener(name: HookName, fn?: HookListener): void;
+
+    clone(): IHooks;
+
+    trigger(
+        name: HookName,
+        event: IDispatcherEvent,
+    ): Promise<void>;
+}

--- a/src/router/module.ts
+++ b/src/router/module.ts
@@ -18,8 +18,9 @@ import type {
     HookErrorListener,
     HookListener,
     HookUnsubscribeFn,
+    IHooks,
 } from '../hook/index.ts';
-import { HookManager, HookName } from '../hook/index.ts';
+import { HookName, Hooks } from '../hook/index.ts';
 import type { Path, PathMatcher } from '../path/index.ts';
 import { isPath } from '../path/index.ts';
 import type { Plugin, PluginInstallContext } from '../plugin/index.ts';
@@ -41,6 +42,16 @@ import type {
     StackEntry,
 } from './types.ts';
 import { acceptsJson, buildRouterPathMatcher, isRouterInstance } from './utils.ts';
+
+const METHOD_TO_REGISTER = {
+    [MethodName.GET]: 'get',
+    [MethodName.POST]: 'post',
+    [MethodName.PUT]: 'put',
+    [MethodName.PATCH]: 'patch',
+    [MethodName.DELETE]: 'delete',
+    [MethodName.HEAD]: 'head',
+    [MethodName.OPTIONS]: 'options',
+} as const satisfies Record<MethodName, keyof Router>;
 
 export class Router implements IRouter {
     /**
@@ -65,11 +76,11 @@ export class Router implements IRouter {
     protected pathMatcher: PathMatcher | undefined;
 
     /**
-     * A hook manager.
+     * Lifecycle hook registry.
      *
      * @protected
      */
-    protected hookManager: HookManager;
+    protected hooks: IHooks;
 
     /**
      * Normalized options for this router instance.
@@ -88,9 +99,17 @@ export class Router implements IRouter {
     constructor(input: RouterOptionsInput = {}) {
         this.name = input.name;
 
-        this.hookManager = new HookManager();
-        this._options = normalizeRouterOptions(input);
-        this.pathMatcher = buildRouterPathMatcher(input.path);
+        const {
+            hooks = new Hooks(),
+            plugins = new Map<string, string | undefined>(),
+            ...options
+        } = input;
+
+        this.hooks = hooks;
+        this.plugins = new Map<string, string | undefined>(plugins);
+
+        this._options = normalizeRouterOptions(options);
+        this.pathMatcher = buildRouterPathMatcher(options.path);
 
         markInstanceof(this, RouterSymbol);
     }
@@ -206,7 +225,7 @@ export class Router implements IRouter {
     }
 
     protected async executePipelineStepStart(context: RouterPipelineContext): Promise<void> {
-        await this.hookManager.trigger(HookName.REQUEST, context.event);
+        await this.hooks.trigger(HookName.REQUEST, context.event);
 
         if (context.event.dispatched) {
             context.step = RouterPipelineStep.FINISH;
@@ -245,7 +264,7 @@ export class Router implements IRouter {
                     }
 
                     if (matchHandlerMethod(method, context.event.method as MethodName)) {
-                        await this.hookManager.trigger(HookName.CHILD_MATCH, context.event);
+                        await this.hooks.trigger(HookName.CHILD_MATCH, context.event);
 
                         if (context.event.dispatched) {
                             context.step = RouterPipelineStep.FINISH;
@@ -266,7 +285,7 @@ export class Router implements IRouter {
                 entry.data.matchPath(context.event.path);
 
             if (match) {
-                await this.hookManager.trigger(HookName.CHILD_MATCH, context.event);
+                await this.hooks.trigger(HookName.CHILD_MATCH, context.event);
 
                 if (context.event.dispatched) {
                     context.step = RouterPipelineStep.FINISH;
@@ -284,7 +303,7 @@ export class Router implements IRouter {
     }
 
     protected async executePipelineStepChildBefore(context: RouterPipelineContext): Promise<void> {
-        await this.hookManager.trigger(HookName.CHILD_DISPATCH_BEFORE, context.event);
+        await this.hooks.trigger(HookName.CHILD_DISPATCH_BEFORE, context.event);
 
         if (context.event.dispatched) {
             context.step = RouterPipelineStep.FINISH;
@@ -294,7 +313,7 @@ export class Router implements IRouter {
     }
 
     protected async executePipelineStepChildAfter(context: RouterPipelineContext): Promise<void> {
-        await this.hookManager.trigger(HookName.CHILD_DISPATCH_AFTER, context.event);
+        await this.hooks.trigger(HookName.CHILD_DISPATCH_AFTER, context.event);
 
         if (context.event.dispatched) {
             context.step = RouterPipelineStep.FINISH;
@@ -382,7 +401,7 @@ export class Router implements IRouter {
         } catch (e) {
             event.error = createError(e);
 
-            await this.hookManager.trigger(HookName.ERROR, event);
+            await this.hooks.trigger(HookName.ERROR, event);
         }
 
         if (!event.dispatched) {
@@ -397,7 +416,7 @@ export class Router implements IRouter {
 
     protected async executePipelineStepFinish(context: RouterPipelineContext): Promise<void> {
         if (context.event.error || context.event.dispatched) {
-            return this.hookManager.trigger(HookName.RESPONSE, context.event);
+            return this.hooks.trigger(HookName.RESPONSE, context.event);
         }
 
         if (
@@ -424,7 +443,7 @@ export class Router implements IRouter {
             context.event.dispatched = true;
         }
 
-        return this.hookManager.trigger(HookName.RESPONSE, context.event);
+        return this.hooks.trigger(HookName.RESPONSE, context.event);
     }
 
     // --------------------------------------------------
@@ -585,6 +604,7 @@ export class Router implements IRouter {
                 type: RouterStackEntryType.HANDLER,
                 data: handler,
                 method,
+                path,
                 pathMatcher: buildHandlerPathMatcher(path ?? handler.path, true),
             });
         }
@@ -592,13 +612,13 @@ export class Router implements IRouter {
 
     // --------------------------------------------------
 
-    use(router: Router): this;
+    use(router: IRouter): this;
 
     use(handler: Handler | HandlerOptions): this;
 
     use(plugin: Plugin): this;
 
-    use(path: Path, router: Router): this;
+    use(path: Path, router: IRouter): this;
 
     use(path: Path, handler: Handler | HandlerOptions): this;
 
@@ -616,6 +636,7 @@ export class Router implements IRouter {
                 this.stack.push({
                     type: RouterStackEntryType.ROUTER,
                     data: item,
+                    path,
                     pathMatcher: buildRouterPathMatcher(path),
                 });
                 continue;
@@ -630,6 +651,7 @@ export class Router implements IRouter {
                 this.stack.push({
                     type: RouterStackEntryType.HANDLER,
                     data: handler,
+                    path,
                 });
                 continue;
             }
@@ -638,6 +660,7 @@ export class Router implements IRouter {
                 this.stack.push({
                     type: RouterStackEntryType.HANDLER,
                     data: item,
+                    path,
                     pathMatcher: buildHandlerPathMatcher(path, !!item.method),
                 });
                 continue;
@@ -699,6 +722,62 @@ export class Router implements IRouter {
     //---------------------------------------------------------------------------------
 
     /**
+     * Return a new `Router` that mirrors this one but owns independent
+     * mountable state.
+     *
+     * The new router has:
+     * - a fresh `stack` array of shallow-copied entries (handlers and child
+     *   routers are shared by reference; only the wrapping entries are new)
+     * - the same `pathMatcher` reference (it is stateless)
+     * - a fresh `Hooks` instance seeded with the current listeners
+     * - a shallow copy of `_options`
+     * - a fresh `plugins` map with the same entries
+     *
+     * Use this when the same logical router needs to be mounted under
+     * multiple paths — each mount can receive its own clone so subsequent
+     * mutations on one mount do not bleed into the others.
+     */
+    clone(): Router {
+        const next = new Router({
+            ...this._options,
+            hooks: this.hooks.clone(),
+            plugins: this.plugins,
+        });
+
+        for (const entry of this.stack) {
+            if (entry.type === RouterStackEntryType.ROUTER) {
+                const data = entry.data.clone();
+                if (entry.path) {
+                    next.use(entry.path, data);
+                } else {
+                    next.use(data);
+                }
+                continue;
+            }
+
+            if (entry.method) {
+                const register = METHOD_TO_REGISTER[entry.method];
+                if (entry.path) {
+                    next[register](entry.path, entry.data);
+                } else {
+                    next[register](entry.data);
+                }
+                continue;
+            }
+
+            if (entry.path) {
+                next.use(entry.path, entry.data);
+            } else {
+                next.use(entry.data);
+            }
+        }
+
+        return next;
+    }
+
+    //---------------------------------------------------------------------------------
+
+    /**
      * Add a hook listener.
      *
      * @param name
@@ -726,7 +805,7 @@ export class Router implements IRouter {
     ): HookUnsubscribeFn;
 
     on(name: HookName, fn: HookListener, priority?: number): HookUnsubscribeFn {
-        return this.hookManager.addListener(name, fn, priority);
+        return this.hooks.addListener(name, fn, priority);
     }
 
     /**
@@ -740,12 +819,12 @@ export class Router implements IRouter {
 
     off(name: HookName, fn?: HookListener): this {
         if (typeof fn === 'undefined') {
-            this.hookManager.removeListener(name);
+            this.hooks.removeListener(name);
 
             return this;
         }
 
-        this.hookManager.removeListener(name, fn);
+        this.hooks.removeListener(name, fn);
         return this;
     }
 }

--- a/src/router/module.ts
+++ b/src/router/module.ts
@@ -737,7 +737,7 @@ export class Router implements IRouter {
      * multiple paths — each mount can receive its own clone so subsequent
      * mutations on one mount do not bleed into the others.
      */
-    clone(): Router {
+    clone(): IRouter {
         const next = new Router({
             ...this._options,
             hooks: this.hooks.clone(),

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -5,12 +5,13 @@ import type {
     Handler,
     HandlerOptions,
 } from '../handler/index.ts';
-import type {
-    HookDefaultListener,
-    HookErrorListener,
-    HookListener,
-    HookName,
-    HookUnsubscribeFn,
+import {
+    type HookDefaultListener,
+    type HookErrorListener,
+    type HookListener,
+    type HookName,
+    type HookUnsubscribeFn,
+    type IHooks,
 } from '../hook/index.ts';
 
 import type { Path, PathMatcher } from '../path/index.ts';
@@ -68,6 +69,9 @@ export type RouterOptions = {
 export type RouterOptionsInput = Omit<Partial<RouterOptions>, 'etag' | 'trustProxy'> & {
     etag?: EtagInput,
     trustProxy?: TrustProxyInput,
+
+    hooks?: IHooks,
+    plugins?: Map<string, string | undefined>
 };
 
 export type RouterPathNode = {
@@ -83,6 +87,11 @@ export type StackRouterEntry = {
     type: typeof RouterStackEntryType.ROUTER,
     data: IRouter,
     /**
+     * Original mount path the entry was registered with, retained so
+     * `Router.clone()` can re-register the entry via the public API.
+     */
+    path?: Path,
+    /**
      * Mount-specific path matcher.
      *
      * Set when the router was mounted under a path (e.g. `parent.use('/api', child)`).
@@ -94,6 +103,11 @@ export type StackRouterEntry = {
 export type StackHandlerEntry = {
     type: typeof RouterStackEntryType.HANDLER,
     data: Handler,
+    /**
+     * Original mount path the entry was registered with, retained so
+     * `Router.clone()` can re-register the entry via the public API.
+     */
+    path?: Path,
     /**
      * Mount-specific path matcher.
      *
@@ -141,6 +155,17 @@ export interface IRouter extends IDispatcher {
      * Test if a path matches this router's mount path.
      */
     matchPath(path: string): boolean;
+
+    /**
+     * Return a new router that mirrors this one but owns independent
+     * mountable state — fresh stack of shallow-copied entries (handlers and
+     * child routers shared by reference), fresh `Hooks` seeded with the
+     * current listeners, shallow copy of options, and a fresh plugins map.
+     *
+     * Intended for mounting the same logical router under multiple paths
+     * without sharing mutable state across mount points.
+     */
+    clone(): IRouter;
 
     /**
      * Check if a plugin with the given name is installed on this router.

--- a/test/unit/router/clone.spec.ts
+++ b/test/unit/router/clone.spec.ts
@@ -1,0 +1,141 @@
+import { 
+    describe, 
+    expect, 
+    it, 
+    vi, 
+} from 'vitest';
+import {
+    Router,
+    defineCoreHandler,
+} from '../../../src';
+import { HookName } from '../../../src/hook';
+import { createTestRequest } from '../../helpers';
+
+describe('src/router clone', () => {
+    it('should produce a router that responds independently', async () => {
+        const original = new Router();
+        original.get('/ping', defineCoreHandler(() => 'pong'));
+
+        const clone = original.clone();
+
+        const fromOriginal = await original.fetch(createTestRequest('/ping'));
+        expect(await fromOriginal.text()).toEqual('pong');
+
+        const fromClone = await clone.fetch(createTestRequest('/ping'));
+        expect(await fromClone.text()).toEqual('pong');
+    });
+
+    it('should allow mounting clones under multiple paths', async () => {
+        const child = new Router();
+        child.get('/ping', defineCoreHandler(() => 'pong'));
+
+        const parent = new Router();
+        for (const path of ['/users', '/members']) {
+            parent.use(path, child.clone());
+        }
+
+        const fromUsers = await parent.fetch(createTestRequest('/users/ping'));
+        expect(await fromUsers.text()).toEqual('pong');
+
+        const fromMembers = await parent.fetch(createTestRequest('/members/ping'));
+        expect(await fromMembers.text()).toEqual('pong');
+    });
+
+    it('should not share stack mutations between original and clone', async () => {
+        const original = new Router();
+        original.get('/a', defineCoreHandler(() => 'A'));
+
+        const clone = original.clone();
+
+        // Add a route only to the clone — original must not see it.
+        clone.get('/b', defineCoreHandler(() => 'B'));
+
+        const cloneB = await clone.fetch(createTestRequest('/b'));
+        expect(cloneB.status).toEqual(200);
+        expect(await cloneB.text()).toEqual('B');
+
+        const originalB = await original.fetch(createTestRequest('/b'));
+        expect(originalB.status).toEqual(404);
+    });
+
+    it('should not share hook listener mutations between original and clone', async () => {
+        const original = new Router();
+        original.get('/', defineCoreHandler(() => 'ok'));
+
+        const sharedListener = vi.fn();
+        original.on(HookName.REQUEST, sharedListener);
+
+        const clone = original.clone();
+
+        const cloneOnlyListener = vi.fn();
+        clone.on(HookName.REQUEST, cloneOnlyListener);
+
+        await clone.fetch(createTestRequest('/'));
+        expect(sharedListener).toHaveBeenCalledTimes(1);
+        expect(cloneOnlyListener).toHaveBeenCalledTimes(1);
+
+        sharedListener.mockClear();
+        cloneOnlyListener.mockClear();
+
+        await original.fetch(createTestRequest('/'));
+        expect(sharedListener).toHaveBeenCalledTimes(1);
+        expect(cloneOnlyListener).not.toHaveBeenCalled();
+    });
+
+    it('should not share plugin registration between original and clone', async () => {
+        const original = new Router();
+        original.use({
+            name: 'plug',
+            version: '1.0.0',
+            install(_router) {
+                // no-op
+            },
+        });
+
+        const clone = original.clone();
+        expect(clone.hasPlugin('plug')).toBe(true);
+        expect(clone.getPluginVersion('plug')).toEqual('1.0.0');
+
+        // Installing a different plugin on the clone must not affect the original.
+        clone.use({
+            name: 'plug-2',
+            install(_router) {
+                // no-op
+            },
+        });
+        expect(clone.hasPlugin('plug-2')).toBe(true);
+        expect(original.hasPlugin('plug-2')).toBe(false);
+    });
+
+    it('should share child handler references — clone is shallow', async () => {
+        const handler = defineCoreHandler(() => 'shared');
+        const original = new Router();
+        original.get('/x', handler);
+
+        const clone = original.clone();
+        const fromClone = await clone.fetch(createTestRequest('/x'));
+        expect(await fromClone.text()).toEqual('shared');
+
+        const fromOriginal = await original.fetch(createTestRequest('/x'));
+        expect(await fromOriginal.text()).toEqual('shared');
+    });
+
+    it('should preserve the intrinsic mount path on the clone', async () => {
+        const original = new Router({ path: '/api' });
+        original.get('/ping', defineCoreHandler(() => 'pong'));
+
+        const clone = original.clone();
+
+        const parent = new Router();
+        parent.use(clone);
+
+        const response = await parent.fetch(createTestRequest('/api/ping'));
+        expect(await response.text()).toEqual('pong');
+    });
+
+    it('should preserve the router name on the clone', () => {
+        const original = new Router({ name: 'foo' });
+        const clone = original.clone();
+        expect(clone.name).toEqual('foo');
+    });
+});


### PR DESCRIPTION
Closes #895.

`Router.prototype.clone()` returns a new router that mirrors the source but owns independent mountable state: shallow-copied stack entries (handlers and child routers shared by reference), a fresh `Hooks` instance seeded with current listeners, a shallow `_options` copy, and a fresh plugins map. Nested routers are cloned recursively.

To keep the implementation free of cross-instance protected-field writes, `RouterOptionsInput` now accepts pre-built `hooks` and `plugins` inputs, and each `StackEntry` retains its original mount `path` so the clone can re-register entries through the public `use()` / method shortcuts.

Also rename `HookManager` → `Hooks` and `IHookManager` → `IHooks` for a shorter, more idiomatic public name, and align the option key to `hooks`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added router cloning capability, enabling independent routing instances with separate configurations and hook subscriptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/routup/routup/pull/896)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->