### PR TITLE
feat(trie)!: feature-complete trie — method bucketing + native parser, drop path-to-regexp from hot path

### DIFF
--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -391,7 +391,7 @@ export class App implements IApp {
             typeof context.matches === 'undefined' ||
             context.matchesPath !== context.event.path
         ) {
-            context.matches = this.router.lookup(context.event.path);
+            context.matches = this.router.lookup(context.event.path, context.event.method);
             context.matchesPath = context.event.path;
         }
 

--- a/src/router/linear/module.ts
+++ b/src/router/linear/module.ts
@@ -43,7 +43,12 @@ export class LinearRouter<T extends ObjectLiteral = ObjectLiteral> implements IR
         this.cache?.clear();
     }
 
-    lookup(path: string): readonly RouteMatch<T>[] {
+    lookup(path: string, _method?: string): readonly RouteMatch<T>[] {
+        // LinearRouter ignores `method`: the dispatcher's own
+        // `matchHandlerMethod` check runs on every returned candidate
+        // anyway, so we simply emit every path-matching route and let
+        // the call site discriminate. Method-aware routers (TrieRouter)
+        // narrow at lookup time for the per-request perf win.
         const cached = this.cache?.get(path);
         if (typeof cached !== 'undefined') {
             return cached;

--- a/src/router/linear/module.ts
+++ b/src/router/linear/module.ts
@@ -90,10 +90,6 @@ export class LinearRouter<T extends ObjectLiteral = ObjectLiteral> implements IR
         return matches;
     }
 
-    get routes(): readonly Route<T>[] {
-        return this._routes;
-    }
-
     clone(): IRouter<T> {
         // Carry the cache *shape* forward (not contents) — fresh
         // cache, same configured class/size. Absent stays absent.

--- a/src/router/trie/module.ts
+++ b/src/router/trie/module.ts
@@ -3,14 +3,84 @@ import type { ICache } from '../../cache/index.ts';
 import type { ObjectLiteral, Route, RouteMatch } from '../../types.ts';
 import type { BaseRouterOptions, IRouter } from '../types.ts';
 import { buildRoutePathMatcher } from '../utils.ts';
-import type { 
-    IndexedRoute, 
-    MethodBuckets, 
-    Segment, 
-    TrieNode, 
+import type {
+    IndexedRoute,
+    MethodBuckets,
+    ParamCapture,
+    Segment,
+    TrieNode,
 } from './types.ts';
+import { parsePath } from './parser.ts';
 
 import { createTrieNode } from './node.ts';
+
+function decodeOrRaw(s: string): string {
+    try {
+        return decodeURIComponent(s);
+    } catch {
+        return s;
+    }
+}
+
+/**
+ * Build a `params` object from a request's pre-split segments using
+ * the variant's pre-computed `ParamCapture[]`. No regex execution —
+ * each capture is one indexed read from `segments` (and a join for
+ * splats). Replaces the `matcher.exec` confirm pass for trie-walked
+ * routes (T3).
+ */
+function extractTrieParams(
+    segments: string[],
+    indexMap: ParamCapture[],
+): Record<string, unknown> {
+    const out = Object.create(null) as Record<string, unknown>;
+    for (const cap of indexMap) {
+        if (cap.kind === 'segment') {
+            out[cap.name] = decodeOrRaw(segments[cap.depth]!);
+        } else {
+            // Splat: capture every remaining segment, joined with '/'.
+            const slice = segments.slice(cap.depth).join('/');
+            out[cap.name] = decodeOrRaw(slice);
+        }
+    }
+    return out;
+}
+
+function trieMatchedPath(segments: string[], matchDepth: number): string {
+    if (matchDepth === 0) {
+        return '/';
+    }
+    return `/${segments.slice(0, matchDepth).join('/')}`;
+}
+
+/**
+ * Pre-compute the `ParamCapture[]` for a variant's segments. Walk
+ * the segments in order; emit one entry per `param` segment and a
+ * terminal one for `splat` (always last). Static segments are
+ * structurally consumed by the trie walk; they don't appear here.
+ */
+function buildParamsIndexMap(segments: Segment[]): ParamCapture[] {
+    const out: ParamCapture[] = [];
+    for (const [i, seg] of segments.entries()) {
+        if (seg.kind === 'param') {
+            out.push({
+                kind: 'segment',
+                depth: i,
+                name: seg.name,
+            });
+        } else if (seg.kind === 'splat') {
+            out.push({
+                kind: 'splat',
+                depth: i,
+                name: seg.name,
+            });
+            // Splats are always last in a variant — the trie parser
+            // emits at most one per variant.
+            break;
+        }
+    }
+    return out;
+}
 
 /**
  * Decide which method buckets a given request method should pull
@@ -73,30 +143,42 @@ function pushIntoBucket<T extends ObjectLiteral>(
 }
 
 /**
- * Radix-trie resolver — registers routes into a per-segment tree at
- * `add()` time and walks the tree at `lookup()` to collect candidates
- * by structure rather than by linear scan.
+ * Radix-trie router — registers routes into a per-segment tree at
+ * `add()` time and walks the tree at `lookup()` to collect
+ * candidates by structure rather than by linear scan.
  *
- * Inspired by Hono's `TrieRouter` and rou3. The trie handles routup's
- * path vocabulary (static segments, `:param`, `*` and `*name` splats);
- * registered paths that contain syntax outside this set (e.g. `{group}`,
- * regex bodies) safely fall through to a `universal` bucket walked
- * linearly on every request — so correctness is preserved at the cost
- * of the trie's per-request savings for those routes.
+ * Inspired by Hono's `TrieRouter` and rou3. The trie handles
+ * routup's path vocabulary directly via its own parser
+ * (`./parser.ts`):
  *
- * The trie identifies candidate routes by structural compatibility;
- * each candidate's `IPathMatcher` is still run once to confirm and
- * extract `params` / `path` exactly as the linear resolver
- * would. Trade-off: one extra `matcher.exec` per candidate, in
- * exchange for skipping most non-matching routes entirely. T3 in
- * the trie roadmap removes the `matcher.exec` step.
+ *   - Static segments (`/users`)
+ *   - Named params (`:id`)
+ *   - Optional params (`:id?`) — expanded to two route variants at
+ *     registration (T2)
+ *   - Optional groups (`/users{/edit}`) — same expansion strategy
+ *   - Bare and named splats (`/files/*`, `/files/*rest`)
+ *
+ * Per-leaf storage is bucketed by HTTP method (T4) so lookup
+ * narrows to the request method's bucket(s) instead of emitting
+ * every entry at the leaf and letting the dispatcher's filter
+ * discard mismatches.
+ *
+ * Param extraction is `paramsIndexMap`-driven (T3): a pre-built
+ * `Array<{ depth, name }>` per variant lets `extractTrieParams`
+ * read params straight from the request's pre-split segments — no
+ * regex execution per match.
+ *
+ * Paths the trie parser doesn't handle (compound segments like
+ * `/files/:n.ext`, escape sequences `\:`, regex constraints) and
+ * empty/root paths fall through to the `universal` bucket. That
+ * bucket still uses `path-to-regexp` via `buildRoutePathMatcher`,
+ * so correctness is preserved.
  *
  * Pure-static-spine fast path (`shortCircuit`): when the request
  * walks a static spine with no param/splat/prefix siblings on any
- * traversed node, the leaf's `exactRoutes` is the full answer —
- * no need to walk the param branch or collect prefix candidates at
- * intermediate nodes. As soon as a branch is encountered, falls
- * through to the regular `walk`.
+ * traversed node, the leaf's `exactRoutes` (filtered to the request
+ * method's buckets) is the full answer — no need to walk the param
+ * branch or collect prefix candidates at intermediate nodes.
  */
 export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRouter<T> {
     protected _routes: Route<T>[];
@@ -124,26 +206,35 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         const index = this._routes.length;
         this._routes.push(route);
 
-        const indexed: IndexedRoute<T> = {
-            route,
-            index,
-            matcher: buildRoutePathMatcher(route),
-        };
-
+        // Empty/root paths bypass the trie entirely — they always
+        // match every request and don't need a path-to-regexp matcher
+        // either.
         if (typeof route.path !== 'string' || route.path === '' || route.path === '/') {
-            this.universal.push(indexed);
+            this.universal.push({ route, index });
             this.cache?.clear();
             return;
         }
 
-        const segments = this.parseRoutePath(route.path);
-        if (segments === null) {
-            this.universal.push(indexed);
+        const variants = parsePath(route.path);
+        if (variants === null) {
+            // Trie parser doesn't handle this syntax (regex
+            // constraints, compound segments like `/files/:n.ext`,
+            // escape sequences). Fall back to path-to-regexp.
+            this.universal.push({
+                route,
+                index,
+                matcher: buildRoutePathMatcher(route),
+            });
             this.cache?.clear();
             return;
         }
 
-        this.insertIntoTrie(segments, indexed);
+        // Each variant becomes an `IndexedRoute` sharing the same
+        // registration `index` so the candidate dedupe keeps them
+        // collapsed to one match per request.
+        for (const segments of variants) {
+            this.insertIntoTrie(segments, route, index);
+        }
         this.cache?.clear();
     }
 
@@ -176,14 +267,22 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         candidates.sort((a, b) => a.index - b.index);
 
         const matches: RouteMatch<T>[] = [];
+        let lastIndex = -1; // dedupe — multiple variants of one route share `index`
         for (const candidate of candidates) {
             const {
                 route,
                 index,
                 matcher,
+                paramsIndexMap,
+                matchDepth,
             } = candidate;
 
+            if (index === lastIndex) {
+                continue;
+            }
+
             if (matcher) {
+                // Universal-bucket route: still uses path-to-regexp.
                 const output = matcher.exec(path);
                 if (typeof output === 'undefined') {
                     continue;
@@ -194,16 +293,30 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
                     params: this.assignParams(output.params),
                     path: output.path,
                 });
+                lastIndex = index;
                 continue;
             }
 
-            // No matcher → route has no mount path (middleware /
-            // mount-less router). Matches every request.
+            if (paramsIndexMap && typeof matchDepth === 'number') {
+                // Trie-walked route: extract params from the request
+                // segments using the pre-built index map. No regex.
+                matches.push({
+                    route,
+                    index,
+                    params: extractTrieParams(segments, paramsIndexMap),
+                    path: trieMatchedPath(segments, matchDepth),
+                });
+                lastIndex = index;
+                continue;
+            }
+
+            // Universal-bucket route with no matcher (empty / root path).
             matches.push({
                 route,
                 index,
                 params: Object.create(null) as Record<string, unknown>,
             });
+            lastIndex = index;
         }
 
         this.cache?.set(cacheKey, matches);
@@ -260,43 +373,6 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         return out;
     }
 
-    /**
-     * Parse a registered path into a list of segments. Returns `null`
-     * when the path contains syntax this resolver doesn't handle
-     * (regex bodies, optional groups, etc.) — the caller then falls
-     * back to the universal bucket so correctness is preserved.
-     */
-    protected parseRoutePath(path: string): Segment[] | null {
-        const trimmed = path.charAt(0) === '/' ? path.slice(1) : path;
-        if (trimmed === '') {
-            return [];
-        }
-
-        const parts = trimmed.split('/');
-        const result: Segment[] = [];
-
-        for (const part of parts) {
-            if (part === '') {
-                continue;
-            }
-            if (part === '*' || (part.charAt(0) === '*' && /^\*[a-zA-Z_]\w*$/.test(part))) {
-                result.push({ kind: 'splat' });
-                continue;
-            }
-            if (part.charAt(0) === ':' && /^:[a-zA-Z_]\w*$/.test(part)) {
-                result.push({ kind: 'param' });
-                continue;
-            }
-            if (/^[a-zA-Z0-9_\-.~%]+$/.test(part)) {
-                result.push({ kind: 'static', value: part });
-                continue;
-            }
-            return null;
-        }
-
-        return result;
-    }
-
     protected parseRequestPath(path: string): string[] {
         const trimmed = path.charAt(0) === '/' ? path.slice(1) : path;
         if (trimmed === '') {
@@ -312,17 +388,28 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         return result;
     }
 
-    protected insertIntoTrie(segments: Segment[], indexed: IndexedRoute<T>): void {
+    protected insertIntoTrie(segments: Segment[], route: Route<T>, index: number): void {
         let node = this.root;
-        const exact = this.isExactMatchRoute(indexed.route);
-        // Empty-string key = method-agnostic. Mounted child apps and
-        // middleware (no method on the entry) end up here; verb-bound
-        // handlers use their concrete method.
-        const methodKey = indexed.route.method ?? '';
+        const exact = this.isExactMatchRoute(route);
+        const methodKey = route.method ?? '';
+        const paramsIndexMap = buildParamsIndexMap(segments);
 
-        for (const seg of segments) {
+        for (const [i, segment] of segments.entries()) {
+            const seg = segment!;
+
             if (seg.kind === 'splat') {
-                pushIntoBucket(node.splatRoutes, methodKey, indexed);
+                // Splat consumes the rest. `matchDepth` is the depth
+                // of *this* trie node (one less than the splat's
+                // index in `segments`, since the splat itself doesn't
+                // create a child node). The splat capture in
+                // `paramsIndexMap` already records that depth via
+                // `cap.depth` — we slice from there at lookup.
+                pushIntoBucket(node.splatRoutes, methodKey, {
+                    route,
+                    index,
+                    paramsIndexMap,
+                    matchDepth: i,
+                });
                 return;
             }
 
@@ -341,6 +428,13 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
             }
             node = child;
         }
+
+        const indexed: IndexedRoute<T> = {
+            route,
+            index,
+            paramsIndexMap,
+            matchDepth: segments.length,
+        };
 
         if (exact) {
             pushIntoBucket(node.exactRoutes, methodKey, indexed);

--- a/src/router/trie/module.ts
+++ b/src/router/trie/module.ts
@@ -299,7 +299,23 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
             this.walk(this.root, segments, 0, candidates, method);
         }
 
-        candidates.sort((a, b) => a.index - b.index);
+        // Sort primarily by registration `index` (preserves dispatch
+        // order across the candidate list). When multiple variants
+        // of one route match the same request — e.g. a prefix
+        // `use('/api/:version?', child)` whose `/api` and
+        // `/api/:version` variants both fire for `/api/v1/...` —
+        // we pick the *most specific* one (greatest `matchDepth`),
+        // so the more-derived variant's `params` and `match.path`
+        // win over the bare-prefix variant. Universal-bucket
+        // candidates have no `matchDepth`; treat as -1 so a trie
+        // variant of the same route wins (in practice they don't
+        // overlap — a route is in either bucket).
+        candidates.sort((a, b) => {
+            if (a.index !== b.index) return a.index - b.index;
+            const ad = a.matchDepth ?? -1;
+            const bd = b.matchDepth ?? -1;
+            return bd - ad;
+        });
 
         const matches: RouteMatch<T>[] = [];
         let lastIndex = -1; // dedupe — multiple variants of one route share `index`
@@ -429,12 +445,12 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
             const seg = segment!;
 
             if (seg.kind === 'splat') {
-                // Splat consumes the rest. `matchDepth` is the depth
-                // of *this* trie node (one less than the splat's
-                // index in `segments`, since the splat itself doesn't
-                // create a child node). The splat capture in
-                // `paramsIndexMap` already records that depth via
-                // `cap.depth` — we slice from there at lookup.
+                // Splat consumes the rest of the request path. The
+                // splat segment itself doesn't create a trie child
+                // node — it lives on the *current* node. So
+                // `matchDepth` is the number of segments matched
+                // before the splat (== current trie depth == `i`,
+                // the splat's index in the variant).
                 pushIntoBucket(node.splatRoutes, methodKey, {
                     route,
                     index,

--- a/src/router/trie/module.ts
+++ b/src/router/trie/module.ts
@@ -46,11 +46,29 @@ function extractTrieParams(
     return out;
 }
 
-function trieMatchedPath(segments: string[], matchDepth: number): string {
-    if (matchDepth === 0) {
+/**
+ * Compute `match.path` (the matched-prefix string) from the request's
+ * segments and the variant's recorded depth.
+ *
+ * - Non-splat variants: prefix = `segments[0..matchDepth].join('/')` —
+ *   exactly what the variant consumed (request length = variant
+ *   length for exact, request length ≥ variant length for prefix).
+ * - Splat variants: the splat absorbed every remaining segment, so
+ *   the matched prefix is the entire request path. This mirrors what
+ *   `path-to-regexp`'s `output.path` would have returned pre-Phase-2
+ *   for `/files/*rest` matching `/files/a/b` (`/files/a/b`, not
+ *   `/files`).
+ */
+function trieMatchedPath(
+    segments: string[],
+    matchDepth: number,
+    splatTerminated: boolean,
+): string {
+    const upTo = splatTerminated ? segments.length : matchDepth;
+    if (upTo === 0) {
         return '/';
     }
-    return `/${segments.slice(0, matchDepth).join('/')}`;
+    return `/${segments.slice(0, upTo).join('/')}`;
 }
 
 /**
@@ -181,45 +199,62 @@ function pushIntoBucket<T extends ObjectLiteral>(
  * branch or collect prefix candidates at intermediate nodes.
  */
 export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRouter<T> {
-    protected _routes: Route<T>[];
+    /**
+     * Monotonic counter assigned as the registration `index` on each
+     * route — the dispatch loop uses it to preserve registration
+     * order across the candidate list. App owns the canonical
+     * `Route<T>[]` list (Plan 019); the trie no longer keeps a
+     * parallel copy.
+     */
+    protected _routeCount: number;
 
     protected root: TrieNode<T>;
 
     /**
      * Routes that bypass the trie — registered with no path, with
-     * the root path `/`, or with a path containing syntax we don't
-     * parse. Walked linearly on every lookup, merged into the result
-     * in registration order.
+     * the root path `/`, or with a path containing syntax the
+     * parser doesn't recognise. Walked linearly on every lookup,
+     * merged into the result in registration order.
      */
     protected universal: IndexedRoute<T>[];
 
     protected cache?: ICache<readonly RouteMatch<T>[]>;
 
     constructor(options: BaseRouterOptions<T> = {}) {
-        this._routes = [];
+        this._routeCount = 0;
         this.root = createTrieNode<T>();
         this.universal = [];
         this.cache = options.cache;
     }
 
     add(route: Route<T>): void {
-        const index = this._routes.length;
-        this._routes.push(route);
+        const index = this._routeCount++;
 
-        // Empty/root paths bypass the trie entirely — they always
-        // match every request and don't need a path-to-regexp matcher
-        // either.
+        // Empty/root paths bypass the trie. We still build a matcher
+        // — `buildRoutePathMatcher` returns one only for the cases
+        // that actually need confirmation:
+        //   - `app.get('/', h)` (exact match) → matcher rejects
+        //     non-`/` requests so the route doesn't promiscuously
+        //     match every path.
+        //   - `app.use('/', mw)` / `app.use(mw)` (prefix or no path)
+        //     → returns `undefined`; the lookup loop treats the
+        //     route as "matches every request" via the no-matcher
+        //     branch, which is exactly what middleware wants.
         if (typeof route.path !== 'string' || route.path === '' || route.path === '/') {
-            this.universal.push({ route, index });
+            this.universal.push({
+                route,
+                index,
+                matcher: buildRoutePathMatcher(route),
+            });
             this.cache?.clear();
             return;
         }
 
         const variants = parsePath(route.path);
         if (variants === null) {
-            // Trie parser doesn't handle this syntax (regex
-            // constraints, compound segments like `/files/:n.ext`,
-            // escape sequences). Fall back to path-to-regexp.
+            // Trie parser doesn't handle this syntax (compound
+            // segments like `/files/:n.ext`, escape sequences,
+            // splat-not-last, …). Fall back to path-to-regexp.
             this.universal.push({
                 route,
                 index,
@@ -304,7 +339,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
                     route,
                     index,
                     params: extractTrieParams(segments, paramsIndexMap),
-                    path: trieMatchedPath(segments, matchDepth),
+                    path: trieMatchedPath(segments, matchDepth, candidate.splatTerminated === true),
                 });
                 lastIndex = index;
                 continue;
@@ -321,10 +356,6 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
 
         this.cache?.set(cacheKey, matches);
         return matches;
-    }
-
-    get routes(): readonly Route<T>[] {
-        return this._routes;
     }
 
     clone(): IRouter<T> {
@@ -409,6 +440,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
                     index,
                     paramsIndexMap,
                     matchDepth: i,
+                    splatTerminated: true,
                 });
                 return;
             }

--- a/src/router/trie/module.ts
+++ b/src/router/trie/module.ts
@@ -1,10 +1,76 @@
+import { MethodName } from '../../constants.ts';
 import type { ICache } from '../../cache/index.ts';
 import type { ObjectLiteral, Route, RouteMatch } from '../../types.ts';
 import type { BaseRouterOptions, IRouter } from '../types.ts';
 import { buildRoutePathMatcher } from '../utils.ts';
-import type { IndexedRoute, Segment, TrieNode } from './types.ts';
+import type { 
+    IndexedRoute, 
+    MethodBuckets, 
+    Segment, 
+    TrieNode, 
+} from './types.ts';
 
 import { createTrieNode } from './node.ts';
+
+/**
+ * Decide which method buckets a given request method should pull
+ * from. Always includes `''` (method-agnostic). For HEAD also
+ * includes GET (per `matchHandlerMethod`). For OPTIONS or no-method
+ * lookups, returns `null` to signal "emit every bucket" — needed so
+ * `event.methodsAllowed` is populated for OPTIONS auto-Allow and so
+ * `IRouter.lookup(path)` (no method) keeps returning a complete
+ * candidate set.
+ */
+function methodBucketKeys(method: string | undefined): readonly string[] | null {
+    if (typeof method === 'undefined' || method === MethodName.OPTIONS) {
+        return null;
+    }
+    if (method === MethodName.HEAD) {
+        return ['', MethodName.HEAD, MethodName.GET];
+    }
+    return ['', method];
+}
+
+function emitBucket<T extends ObjectLiteral>(
+    buckets: MethodBuckets<T>,
+    method: string | undefined,
+    out: IndexedRoute<T>[],
+): void {
+    const keys = methodBucketKeys(method);
+    if (keys === null) {
+        for (const k in buckets) {
+            const list = buckets[k]!;
+            for (const r of list) out.push(r);
+        }
+        return;
+    }
+    for (const k of keys) {
+        const list = buckets[k];
+        if (!list) continue;
+        for (const r of list) out.push(r);
+    }
+}
+
+function hasAnyBucket<T extends ObjectLiteral>(buckets: MethodBuckets<T>): boolean {
+    // eslint-disable-next-line no-unreachable-loop
+    for (const _k in buckets) {
+        return true;
+    }
+    return false;
+}
+
+function pushIntoBucket<T extends ObjectLiteral>(
+    buckets: MethodBuckets<T>,
+    methodKey: string,
+    route: IndexedRoute<T>,
+): void {
+    const bucket = buckets[methodKey];
+    if (bucket) {
+        bucket.push(route);
+    } else {
+        buckets[methodKey] = [route];
+    }
+}
 
 /**
  * Radix-trie resolver — registers routes into a per-segment tree at
@@ -81,8 +147,12 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         this.cache?.clear();
     }
 
-    lookup(path: string): readonly RouteMatch<T>[] {
-        const cached = this.cache?.get(path);
+    lookup(path: string, method?: string): readonly RouteMatch<T>[] {
+        // Cache key includes the method bucket — different methods at
+        // the same path now resolve to different candidate sets, so
+        // sharing a cache entry across methods would leak matches.
+        const cacheKey = `${method ?? ''}\t${path}`;
+        const cached = this.cache?.get(cacheKey);
         if (typeof cached !== 'undefined') {
             return cached;
         }
@@ -94,13 +164,13 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         }
 
         const segments = this.parseRequestPath(path);
-        const shortCircuit = this.shortCircuit(segments);
+        const shortCircuit = this.shortCircuit(segments, method);
         if (shortCircuit !== null) {
             for (const c of shortCircuit) {
                 candidates.push(c);
             }
         } else {
-            this.walk(this.root, segments, 0, candidates);
+            this.walk(this.root, segments, 0, candidates, method);
         }
 
         candidates.sort((a, b) => a.index - b.index);
@@ -136,7 +206,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
             });
         }
 
-        this.cache?.set(path, matches);
+        this.cache?.set(cacheKey, matches);
         return matches;
     }
 
@@ -153,13 +223,14 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
     /**
      * T1: returns the pre-computed candidate list when the request's
      * static spine has no param sibling, no prefix routes, and no
-     * splats along the way. The leaf node's `exactRoutes` is then
-     * the complete answer — no need to walk the param branch or
-     * collect prefix/splat candidates from intermediate nodes. When
-     * any branch is encountered, returns `null` and the caller falls
-     * through to the regular `walk`.
+     * splats along the way. The leaf node's `exactRoutes` (filtered
+     * to the request method's buckets) is then the complete answer —
+     * no need to walk the param branch or collect prefix/splat
+     * candidates from intermediate nodes. When any branch is
+     * encountered, returns `null` and the caller falls through to
+     * the regular `walk`.
      */
-    protected shortCircuit(segments: string[]): IndexedRoute<T>[] | null {
+    protected shortCircuit(segments: string[], method: string | undefined): IndexedRoute<T>[] | null {
         let node = this.root;
 
         for (const segment of segments) {
@@ -167,7 +238,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
             // param-child might match the current segment, a splat
             // would fire, and prefix routes would belong in the
             // result. All of these need the full walk.
-            if (node.paramChild || node.splatRoutes.length > 0 || node.prefixRoutes.length > 0) {
+            if (node.paramChild || hasAnyBucket(node.splatRoutes) || node.prefixRoutes.length > 0) {
                 return null;
             }
 
@@ -178,13 +249,15 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
             node = child;
         }
 
-        if (node.paramChild || node.splatRoutes.length > 0 || node.prefixRoutes.length > 0) {
+        if (node.paramChild || hasAnyBucket(node.splatRoutes) || node.prefixRoutes.length > 0) {
             return null;
         }
 
-        // Pure static spine reached the leaf — `exactRoutes` is the
-        // complete answer for this request.
-        return node.exactRoutes;
+        // Pure static spine reached the leaf — `exactRoutes` (for the
+        // request method's relevant buckets) is the complete answer.
+        const out: IndexedRoute<T>[] = [];
+        emitBucket(node.exactRoutes, method, out);
+        return out;
     }
 
     /**
@@ -242,10 +315,14 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
     protected insertIntoTrie(segments: Segment[], indexed: IndexedRoute<T>): void {
         let node = this.root;
         const exact = this.isExactMatchRoute(indexed.route);
+        // Empty-string key = method-agnostic. Mounted child apps and
+        // middleware (no method on the entry) end up here; verb-bound
+        // handlers use their concrete method.
+        const methodKey = indexed.route.method ?? '';
 
         for (const seg of segments) {
             if (seg.kind === 'splat') {
-                node.splatRoutes.push(indexed);
+                pushIntoBucket(node.splatRoutes, methodKey, indexed);
                 return;
             }
 
@@ -266,8 +343,10 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         }
 
         if (exact) {
-            node.exactRoutes.push(indexed);
+            pushIntoBucket(node.exactRoutes, methodKey, indexed);
         } else {
+            // Prefix routes (middleware / mounted apps) stay flat —
+            // they're method-agnostic by design.
             node.prefixRoutes.push(indexed);
         }
     }
@@ -277,18 +356,15 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         segments: string[],
         depth: number,
         collected: IndexedRoute<T>[],
+        method: string | undefined,
     ): void {
         // Splats at this depth match any request path that reaches here.
-        for (const s of node.splatRoutes) {
-            collected.push(s);
-        }
+        emitBucket(node.splatRoutes, method, collected);
 
         if (depth === segments.length) {
             // Request path is fully consumed at this node: collect
             // both exact-match and prefix-match routes that ended here.
-            for (const e of node.exactRoutes) {
-                collected.push(e);
-            }
+            emitBucket(node.exactRoutes, method, collected);
             for (const p of node.prefixRoutes) {
                 collected.push(p);
             }
@@ -296,7 +372,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         }
 
         // Going deeper — prefix routes at this node match any
-        // continuation (middleware / nested routers).
+        // continuation (middleware / nested apps).
         for (const p of node.prefixRoutes) {
             collected.push(p);
         }
@@ -305,11 +381,11 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
 
         const staticChild = node.staticChildren.get(seg);
         if (staticChild) {
-            this.walk(staticChild, segments, depth + 1, collected);
+            this.walk(staticChild, segments, depth + 1, collected, method);
         }
 
         if (node.paramChild) {
-            this.walk(node.paramChild, segments, depth + 1, collected);
+            this.walk(node.paramChild, segments, depth + 1, collected, method);
         }
     }
 

--- a/src/router/trie/node.ts
+++ b/src/router/trie/node.ts
@@ -1,11 +1,15 @@
 import type { ObjectLiteral } from '../../types.ts';
-import type { TrieNode } from './types.ts';
+import type { MethodBuckets, TrieNode } from './types.ts';
+
+export function createMethodBuckets<T extends ObjectLiteral = ObjectLiteral>(): MethodBuckets<T> {
+    return Object.create(null) as MethodBuckets<T>;
+}
 
 export function createTrieNode<T extends ObjectLiteral = ObjectLiteral>(): TrieNode<T> {
     return {
         staticChildren: new Map(),
-        splatRoutes: [],
-        exactRoutes: [],
+        splatRoutes: createMethodBuckets<T>(),
+        exactRoutes: createMethodBuckets<T>(),
         prefixRoutes: [],
     };
 }

--- a/src/router/trie/parser.ts
+++ b/src/router/trie/parser.ts
@@ -19,9 +19,9 @@ import type { Segment } from './types.ts';
  * `index` so they dedupe naturally on the candidate list.
  *
  * Returns `null` when the path uses syntax outside this surface
- * (regex constraints `:name(\d+)`, compound segments `/files/:n.ext`,
- * escape sequences `\:`, …). The caller falls back to the universal
- * bucket so correctness is preserved via path-to-regexp.
+ * (compound segments `/files/:n.ext`, escape sequences `\:`, regex
+ * constraints, splat-not-last, …). The caller falls back to the
+ * universal bucket so correctness is preserved via path-to-regexp.
  *
  * Variant cap: nested optional groups expand combinatorially. The
  * parser caps the variant count at `MAX_VARIANTS` and falls back to
@@ -30,6 +30,8 @@ import type { Segment } from './types.ts';
  */
 
 const MAX_VARIANTS = 16;
+
+const PARAM_NAME = /^[a-zA-Z_]\w*$/;
 
 type ParamToken = {
     kind: 'param';
@@ -42,8 +44,6 @@ type Token = { kind: 'literal'; value: string } |
     { kind: 'splat'; name: string } |
     { kind: 'groupOpen' } |
     { kind: 'groupClose' };
-
-const PARAM_NAME = /^[a-zA-Z_]\w*/;
 
 /**
  * Tokenize a single path segment (the substring between two `/`).
@@ -58,21 +58,13 @@ function tokenizeSegment(segment: string): Token | null {
         return null;
     }
 
-    // Optional group: `{...}` — emit as group open/close markers
-    // around the expansion of the inner segment. Currently the
-    // inner is only tokenized as a single segment; nested slashes
-    // inside a group fall back to the universal bucket.
-    if (segment.charAt(0) === '{' && segment.charAt(segment.length - 1) === '}') {
-        return null; // groups are slash-spanning — handled at the path level
-    }
-
     if (segment === '*') {
         return { kind: 'splat', name: '*' };
     }
 
     if (segment.charAt(0) === '*') {
         const rest = segment.slice(1);
-        if (PARAM_NAME.test(rest) && PARAM_NAME.exec(rest)![0] === rest) {
+        if (PARAM_NAME.test(rest)) {
             return { kind: 'splat', name: rest };
         }
         return null;
@@ -81,7 +73,7 @@ function tokenizeSegment(segment: string): Token | null {
     if (segment.charAt(0) === ':') {
         const optional = segment.charAt(segment.length - 1) === '?';
         const nameRaw = optional ? segment.slice(1, -1) : segment.slice(1);
-        if (PARAM_NAME.test(nameRaw) && PARAM_NAME.exec(nameRaw)![0] === nameRaw) {
+        if (PARAM_NAME.test(nameRaw)) {
             return {
                 kind: 'param',
                 name: nameRaw,
@@ -183,7 +175,7 @@ function tokenizePath(path: string): Token[] | null {
 }
 
 /**
- * Expand the token stream into one or more concrete `Segment[]`
+ * Expand the token stream into one or more concrete `Token[]`
  * variants by:
  *   1. Splitting `groupOpen` … `groupClose` runs into a "with run"
  *      and a "without run" choice (one optional group → ×2 variants).
@@ -192,8 +184,13 @@ function tokenizePath(path: string): Token[] | null {
  *
  * Caps at `MAX_VARIANTS` — beyond that, returns `null` so the path
  * falls back to the universal bucket.
+ *
+ * Returns `Token[][]` (not `Segment[][]`) so the recursive
+ * group-expansion can splice inner variants back into the outer
+ * token stream without a lossy round-trip through `Segment`.
+ * `parsePath` does the final `Token → Segment` projection.
  */
-function expand(tokens: Token[]): Segment[][] | null {
+function expand(tokens: Token[]): Token[][] | null {
     let variants: Token[][] = [[]];
 
     for (let i = 0; i < tokens.length; i++) {
@@ -219,22 +216,24 @@ function expand(tokens: Token[]): Segment[][] | null {
                 return null;
             }
             const inner = tokens.slice(i + 1, close);
-            const expanded = expand(inner);
-            if (expanded === null) {
+            const expandedInner = expand(inner);
+            if (expandedInner === null) {
                 return null;
             }
-            // Two choices for this run: with each inner expansion, or without.
+            // Two choices for this run: keep without, or splice in
+            // each inner variant. Cap-check before each push so
+            // we never exceed `MAX_VARIANTS`.
             const next: Token[][] = [];
             for (const v of variants) {
-                // Without
-                next.push(v.slice());
-                // With each inner variant
-                for (const innerVariant of expanded) {
-                    const innerTokens: Token[] = innerVariant.map(toToken);
-                    next.push(v.concat(innerTokens));
-                }
-                if (next.length > MAX_VARIANTS) {
+                if (next.length >= MAX_VARIANTS) {
                     return null;
+                }
+                next.push(v.slice());
+                for (const innerVariant of expandedInner) {
+                    if (next.length >= MAX_VARIANTS) {
+                        return null;
+                    }
+                    next.push(v.concat(innerVariant));
                 }
             }
             variants = next;
@@ -244,17 +243,20 @@ function expand(tokens: Token[]): Segment[][] | null {
 
         if (token.kind === 'param' && token.optional) {
             const stripped: Token = {
-                kind: 'param', 
-                name: token.name, 
-                optional: false, 
+                kind: 'param',
+                name: token.name,
+                optional: false,
             };
             const next: Token[][] = [];
             for (const v of variants) {
-                next.push(v.slice());                  // without the optional param
-                next.push(v.concat([stripped]));       // with the param
-                if (next.length > MAX_VARIANTS) {
+                if (next.length >= MAX_VARIANTS) {
                     return null;
                 }
+                next.push(v.slice());
+                if (next.length >= MAX_VARIANTS) {
+                    return null;
+                }
+                next.push(v.concat([stripped]));
             }
             variants = next;
             continue;
@@ -265,41 +267,32 @@ function expand(tokens: Token[]): Segment[][] | null {
         }
     }
 
-    // Convert tokens → Segment[]. Group markers should all be
-    // consumed by now; if any leak through it's a parser bug.
-    const result: Segment[][] = [];
-    for (const v of variants) {
-        const segments: Segment[] = [];
-        for (const t of v) {
-            if (t.kind === 'groupOpen' || t.kind === 'groupClose') {
-                return null;
-            }
-            if (t.kind === 'literal') {
-                segments.push({ kind: 'static', value: t.value });
-            } else if (t.kind === 'param') {
-                segments.push({ kind: 'param', name: t.name });
-            } else {
-                segments.push({ kind: 'splat', name: t.name });
-            }
-        }
-        result.push(segments);
-    }
-    return result;
+    return variants;
+}
+
+function tokenToSegment(t: Token): Segment | null {
+    if (t.kind === 'literal') return { kind: 'static', value: t.value };
+    if (t.kind === 'param') return { kind: 'param', name: t.name };
+    if (t.kind === 'splat') return { kind: 'splat', name: t.name };
+    // groupOpen/groupClose should be consumed by `expand`; if any
+    // leak through, the path is malformed.
+    return null;
 }
 
 /**
- * Bridge between Segment (post-expansion) and Token (in-flight). Used
- * when an optional group is expanded recursively — the inner Segment[]
- * needs to slot back in as Token[] for the outer expansion pass.
+ * Stable, structural identity for a variant — used to drop duplicate
+ * expansions like `/users{/:id?}` (which produces the bare-`/users`
+ * variant twice: once from the "without group" branch and once from
+ * the "with group, without optional param" branch).
  */
-function toToken(seg: Segment): Token {
-    if (seg.kind === 'static') return { kind: 'literal', value: seg.value };
-    if (seg.kind === 'param') {return {
-        kind: 'param', 
-        name: seg.name, 
-        optional: false, 
-    };}
-    return { kind: 'splat', name: seg.name };
+function variantKey(segs: Segment[]): string {
+    let out = '';
+    for (const s of segs) {
+        if (s.kind === 'static') out += `/s:${s.value}`;
+        else if (s.kind === 'param') out += `/p:${s.name}`;
+        else out += `/*:${s.name}`;
+    }
+    return out;
 }
 
 export function parsePath(path: string): Segment[][] | null {
@@ -307,5 +300,42 @@ export function parsePath(path: string): Segment[][] | null {
     if (tokens === null) {
         return null;
     }
-    return expand(tokens);
+    const variants = expand(tokens);
+    if (variants === null) {
+        return null;
+    }
+
+    const result: Segment[][] = [];
+    const seen = new Set<string>();
+
+    for (const v of variants) {
+        const segs: Segment[] = [];
+        for (const t of v) {
+            const s = tokenToSegment(t);
+            if (s === null) {
+                return null;
+            }
+            segs.push(s);
+        }
+
+        // Splat must be the terminal segment in any variant —
+        // otherwise the trie's `insertIntoTrie` would silently drop
+        // every segment after the splat (T3 dropped the
+        // `matcher.exec` confirm pass that previously caught this).
+        // Fall back to the universal bucket so path-to-regexp can
+        // handle the route honestly.
+        for (let i = 0; i < segs.length - 1; i++) {
+            if (segs[i]!.kind === 'splat') {
+                return null;
+            }
+        }
+
+        const key = variantKey(segs);
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        result.push(segs);
+    }
+    return result;
 }

--- a/src/router/trie/parser.ts
+++ b/src/router/trie/parser.ts
@@ -1,0 +1,311 @@
+import type { Segment } from './types.ts';
+
+/**
+ * Trie-native path parser.
+ *
+ * Replaces the call-out to `path-to-regexp` for the syntax surface
+ * the trie advertises:
+ *
+ *   - Static segments: `users`, `v1`
+ *   - Named params:    `:id`, `:slug`
+ *   - Optional params: `:id?`            (T2 — expanded to two variants)
+ *   - Optional groups: `{...}`           (T2 — expanded to two variants)
+ *   - Bare splat:      `*`               (matches the rest of the path)
+ *   - Named splat:     `*rest`
+ *
+ * Returns a list of `Segment[]` *variants* — one path string can
+ * expand into multiple route variants when it contains optional
+ * markers. The trie inserts every variant with the same registration
+ * `index` so they dedupe naturally on the candidate list.
+ *
+ * Returns `null` when the path uses syntax outside this surface
+ * (regex constraints `:name(\d+)`, compound segments `/files/:n.ext`,
+ * escape sequences `\:`, …). The caller falls back to the universal
+ * bucket so correctness is preserved via path-to-regexp.
+ *
+ * Variant cap: nested optional groups expand combinatorially. The
+ * parser caps the variant count at `MAX_VARIANTS` and falls back to
+ * the universal bucket above that — registration-time explosion
+ * isn't worth the lookup-time win on degenerate paths.
+ */
+
+const MAX_VARIANTS = 16;
+
+type ParamToken = {
+    kind: 'param';
+    name: string;
+    optional: boolean;
+};
+
+type Token = { kind: 'literal'; value: string } |
+    ParamToken |
+    { kind: 'splat'; name: string } |
+    { kind: 'groupOpen' } |
+    { kind: 'groupClose' };
+
+const PARAM_NAME = /^[a-zA-Z_]\w*/;
+
+/**
+ * Tokenize a single path segment (the substring between two `/`).
+ * Returns `null` if the segment uses syntax we don't handle.
+ *
+ * Each segment must yield exactly one token — compound segments
+ * (`/files/:n.ext`, `/users-:id`) produce multiple tokens and so
+ * trip this check, falling back to the universal bucket.
+ */
+function tokenizeSegment(segment: string): Token | null {
+    if (segment === '') {
+        return null;
+    }
+
+    // Optional group: `{...}` — emit as group open/close markers
+    // around the expansion of the inner segment. Currently the
+    // inner is only tokenized as a single segment; nested slashes
+    // inside a group fall back to the universal bucket.
+    if (segment.charAt(0) === '{' && segment.charAt(segment.length - 1) === '}') {
+        return null; // groups are slash-spanning — handled at the path level
+    }
+
+    if (segment === '*') {
+        return { kind: 'splat', name: '*' };
+    }
+
+    if (segment.charAt(0) === '*') {
+        const rest = segment.slice(1);
+        if (PARAM_NAME.test(rest) && PARAM_NAME.exec(rest)![0] === rest) {
+            return { kind: 'splat', name: rest };
+        }
+        return null;
+    }
+
+    if (segment.charAt(0) === ':') {
+        const optional = segment.charAt(segment.length - 1) === '?';
+        const nameRaw = optional ? segment.slice(1, -1) : segment.slice(1);
+        if (PARAM_NAME.test(nameRaw) && PARAM_NAME.exec(nameRaw)![0] === nameRaw) {
+            return {
+                kind: 'param',
+                name: nameRaw,
+                optional,
+            };
+        }
+        return null;
+    }
+
+    // Plain static segment — only allow URL-safe characters. A
+    // segment with a `:` mid-string (compound) trips here too.
+    if (/^[a-zA-Z0-9_\-.~%]+$/.test(segment)) {
+        return { kind: 'literal', value: segment };
+    }
+
+    return null;
+}
+
+/**
+ * Tokenize the full path into a token stream, recognizing slash-
+ * spanning optional groups (`/users{/edit/:id}`).
+ *
+ * The group-open marker is emitted in place of the leading `/`
+ * inside `{...}`; group-close before the trailing `}`. The walker
+ * later expands by either keeping the run between markers or
+ * dropping it.
+ */
+function tokenizePath(path: string): Token[] | null {
+    const trimmed = path.charAt(0) === '/' ? path.slice(1) : path;
+    if (trimmed === '') {
+        return [];
+    }
+
+    const tokens: Token[] = [];
+    let i = 0;
+    const n = trimmed.length;
+
+    while (i < n) {
+        if (trimmed.charAt(i) === '{') {
+            // Find matching `}` (no nesting support — fall back if
+            // we see a nested `{` before the close).
+            let close = -1;
+            for (let j = i + 1; j < n; j++) {
+                const c = trimmed.charAt(j);
+                if (c === '{') {
+                    return null;
+                }
+                if (c === '}') {
+                    close = j;
+                    break;
+                }
+            }
+            if (close === -1) {
+                return null;
+            }
+            const inner = trimmed.slice(i + 1, close);
+            // Inner must start with `/` so the group is slash-spanning
+            // (matches path-to-regexp v8's `{/segment}` shape).
+            if (inner.charAt(0) !== '/') {
+                return null;
+            }
+            tokens.push({ kind: 'groupOpen' });
+            const innerTokens = tokenizePath(inner);
+            if (innerTokens === null) {
+                return null;
+            }
+            for (const t of innerTokens) {
+                tokens.push(t);
+            }
+            tokens.push({ kind: 'groupClose' });
+            i = close + 1;
+            continue;
+        }
+
+        // Read until next `/` or `{`.
+        let segEnd = i;
+        while (segEnd < n) {
+            const c = trimmed.charAt(segEnd);
+            if (c === '/' || c === '{') {
+                break;
+            }
+            segEnd++;
+        }
+        const segment = trimmed.slice(i, segEnd);
+        if (segment !== '') {
+            const token = tokenizeSegment(segment);
+            if (token === null) {
+                return null;
+            }
+            tokens.push(token);
+        }
+        i = segEnd;
+        if (i < n && trimmed.charAt(i) === '/') {
+            i++; // skip the separator
+        }
+    }
+
+    return tokens;
+}
+
+/**
+ * Expand the token stream into one or more concrete `Segment[]`
+ * variants by:
+ *   1. Splitting `groupOpen` … `groupClose` runs into a "with run"
+ *      and a "without run" choice (one optional group → ×2 variants).
+ *   2. Splitting `param.optional = true` into a "with" and "without"
+ *      choice (one `:id?` → ×2 variants).
+ *
+ * Caps at `MAX_VARIANTS` — beyond that, returns `null` so the path
+ * falls back to the universal bucket.
+ */
+function expand(tokens: Token[]): Segment[][] | null {
+    let variants: Token[][] = [[]];
+
+    for (let i = 0; i < tokens.length; i++) {
+        const token = tokens[i]!;
+
+        if (token.kind === 'groupOpen') {
+            // Find matching `groupClose`. Nested groups already
+            // rejected at tokenize time so this is one level deep.
+            let depth = 1;
+            let close = -1;
+            for (let j = i + 1; j < tokens.length; j++) {
+                const t = tokens[j]!;
+                if (t.kind === 'groupOpen') depth++;
+                else if (t.kind === 'groupClose') {
+                    depth--;
+                    if (depth === 0) {
+                        close = j;
+                        break;
+                    }
+                }
+            }
+            if (close === -1) {
+                return null;
+            }
+            const inner = tokens.slice(i + 1, close);
+            const expanded = expand(inner);
+            if (expanded === null) {
+                return null;
+            }
+            // Two choices for this run: with each inner expansion, or without.
+            const next: Token[][] = [];
+            for (const v of variants) {
+                // Without
+                next.push(v.slice());
+                // With each inner variant
+                for (const innerVariant of expanded) {
+                    const innerTokens: Token[] = innerVariant.map(toToken);
+                    next.push(v.concat(innerTokens));
+                }
+                if (next.length > MAX_VARIANTS) {
+                    return null;
+                }
+            }
+            variants = next;
+            i = close;
+            continue;
+        }
+
+        if (token.kind === 'param' && token.optional) {
+            const stripped: Token = {
+                kind: 'param', 
+                name: token.name, 
+                optional: false, 
+            };
+            const next: Token[][] = [];
+            for (const v of variants) {
+                next.push(v.slice());                  // without the optional param
+                next.push(v.concat([stripped]));       // with the param
+                if (next.length > MAX_VARIANTS) {
+                    return null;
+                }
+            }
+            variants = next;
+            continue;
+        }
+
+        for (const v of variants) {
+            v.push(token);
+        }
+    }
+
+    // Convert tokens → Segment[]. Group markers should all be
+    // consumed by now; if any leak through it's a parser bug.
+    const result: Segment[][] = [];
+    for (const v of variants) {
+        const segments: Segment[] = [];
+        for (const t of v) {
+            if (t.kind === 'groupOpen' || t.kind === 'groupClose') {
+                return null;
+            }
+            if (t.kind === 'literal') {
+                segments.push({ kind: 'static', value: t.value });
+            } else if (t.kind === 'param') {
+                segments.push({ kind: 'param', name: t.name });
+            } else {
+                segments.push({ kind: 'splat', name: t.name });
+            }
+        }
+        result.push(segments);
+    }
+    return result;
+}
+
+/**
+ * Bridge between Segment (post-expansion) and Token (in-flight). Used
+ * when an optional group is expanded recursively — the inner Segment[]
+ * needs to slot back in as Token[] for the outer expansion pass.
+ */
+function toToken(seg: Segment): Token {
+    if (seg.kind === 'static') return { kind: 'literal', value: seg.value };
+    if (seg.kind === 'param') {return {
+        kind: 'param', 
+        name: seg.name, 
+        optional: false, 
+    };}
+    return { kind: 'splat', name: seg.name };
+}
+
+export function parsePath(path: string): Segment[][] | null {
+    const tokens = tokenizePath(path);
+    if (tokens === null) {
+        return null;
+    }
+    return expand(tokens);
+}

--- a/src/router/trie/parser.ts
+++ b/src/router/trie/parser.ts
@@ -135,6 +135,15 @@ function tokenizePath(path: string): Token[] | null {
             if (inner.charAt(0) !== '/') {
                 return null;
             }
+            // What follows the closing `}` must end the segment —
+            // either end-of-path, a `/` separator, or another `{`
+            // group. Anything else (e.g. `/a{/b}c`) is compound
+            // syntax the trie can't represent; fall back to the
+            // universal bucket so path-to-regexp can handle it.
+            const after = close + 1 < n ? trimmed.charAt(close + 1) : '';
+            if (after !== '' && after !== '/' && after !== '{') {
+                return null;
+            }
             tokens.push({ kind: 'groupOpen' });
             const innerTokens = tokenizePath(inner);
             if (innerTokens === null) {

--- a/src/router/trie/types.ts
+++ b/src/router/trie/types.ts
@@ -11,24 +11,39 @@ export type Segment = { kind: 'static'; value: string } |
     { kind: 'param' } |
     { kind: 'splat' };
 
+/**
+ * Method-keyed bucket of indexed routes. The empty-string key
+ * (`''`) holds method-agnostic entries (handlers registered without
+ * a method binding). Stored as a prototype-less object so user-
+ * controlled method strings can't collide with `Object.prototype`
+ * keys (`__proto__`, `hasOwnProperty`, …).
+ */
+export type MethodBuckets<T extends ObjectLiteral = ObjectLiteral> = Record<
+    string,
+    IndexedRoute<T>[]
+>;
+
 export type TrieNode<T extends ObjectLiteral = ObjectLiteral> = {
     staticChildren: Map<string, TrieNode<T>>;
     paramChild?: TrieNode<T>;
     /**
      * Entries whose path ends with a splat at this depth (`/files/*`,
      * `/foo/*name`, …). They match the current node and every deeper
-     * request path.
+     * request path. Bucketed by HTTP method (`''` = method-agnostic).
      */
-    splatRoutes: IndexedRoute<T>[];
+    splatRoutes: MethodBuckets<T>;
     /**
      * Exact-match routes whose path ends at this node — only matched
      * when the request path is fully consumed at this depth.
+     * Bucketed by HTTP method (`''` = method-agnostic).
      */
-    exactRoutes: IndexedRoute<T>[];
+    exactRoutes: MethodBuckets<T>;
     /**
-     * Prefix-match routes (middleware / nested routers) whose path
-     * ends at this node — matched whenever this node is reached,
-     * regardless of remaining depth.
+     * Prefix-match routes (middleware / nested apps) whose path ends
+     * at this node — matched whenever this node is reached,
+     * regardless of remaining depth. Not bucketed: middleware is
+     * method-agnostic by design (the inner handler does its own
+     * method discrimination).
      */
     prefixRoutes: IndexedRoute<T>[];
 };

--- a/src/router/trie/types.ts
+++ b/src/router/trie/types.ts
@@ -1,15 +1,71 @@
 import type { IPathMatcher } from '../../path/index.ts';
 import type { ObjectLiteral, Route } from '../../types.ts';
 
+/**
+ * Tagged param-extraction instruction. Built at registration time
+ * during `insertIntoTrie`; consumed at lookup time to build the
+ * params object directly from the request's pre-split segments —
+ * no regex execution per match.
+ *
+ * - `segment`: capture `segments[depth]` as `name`.
+ * - `splat`: capture `segments[depth..]` joined with `/` as `name`.
+ *   `name` is `'*'` for the unnamed bare splat (`/files/*`).
+ */
+export type ParamCapture = {
+    kind: 'segment';
+    depth: number;
+    name: string;
+} | {
+    kind: 'splat';
+    depth: number;
+    name: string;
+};
+
+/**
+ * Per-variant route record stored at a trie leaf.
+ *
+ * `paramsIndexMap` populated for trie-walked variants so lookup can
+ * extract params without running `matcher.exec`. `matcher` is only
+ * populated for universal-bucket routes (registered paths the trie
+ * parser couldn't handle — regex constraints, compound segments,
+ * escapes — that fall back to path-to-regexp).
+ *
+ * `index` is shared across every variant produced from a single
+ * `add()` call so the candidate list deduplicates naturally on
+ * registration order.
+ */
 export type IndexedRoute<T extends ObjectLiteral = ObjectLiteral> = {
     route: Route<T>;
     index: number;
-    matcher: IPathMatcher | undefined;
+    /**
+     * Universal-bucket-only — populated for paths the trie parser
+     * couldn't handle (regex constraints, compound segments, escapes).
+     * The lookup loop runs `matcher.exec(path)` to confirm the match
+     * and extract params, identical to `LinearRouter`.
+     */
+    matcher?: IPathMatcher;
+    /**
+     * Trie-walked-only — populated for variants that came out of
+     * `parsePath`. The lookup loop walks this list to build the
+     * `params` object directly from request segments, no regex.
+     */
+    paramsIndexMap?: ParamCapture[];
+    /**
+     * Trie-walked-only — how many request segments this variant
+     * consumes when matched. Used to compute `match.path` (the
+     * matched prefix) at lookup time without re-running a matcher.
+     *
+     * - Exact / prefix variants: `segments.length` (consume up to
+     *   the leaf).
+     * - Splat variants: depth of the splat segment (it then absorbs
+     *   the rest).
+     */
+    matchDepth?: number;
 };
 
 export type Segment = { kind: 'static'; value: string } |
-    { kind: 'param' } |
-    { kind: 'splat' };
+    { kind: 'param'; name: string } |
+    { kind: 'splat'; name: string };
 
 /**
  * Method-keyed bucket of indexed routes. The empty-string key

--- a/src/router/trie/types.ts
+++ b/src/router/trie/types.ts
@@ -58,9 +58,16 @@ export type IndexedRoute<T extends ObjectLiteral = ObjectLiteral> = {
      * - Exact / prefix variants: `segments.length` (consume up to
      *   the leaf).
      * - Splat variants: depth of the splat segment (it then absorbs
-     *   the rest).
+     *   the rest — see `splatTerminated`).
      */
     matchDepth?: number;
+    /**
+     * Trie-walked-only — `true` when this variant ends in a splat.
+     * `match.path` is then computed from the *full* request length
+     * (the splat absorbed every remaining segment), not from
+     * `matchDepth` (which is only the depth of the splat node).
+     */
+    splatTerminated?: boolean;
 };
 
 export type Segment = { kind: 'static'; value: string } |

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -54,8 +54,21 @@ export interface IRouter<T extends ObjectLiteral = ObjectLiteral> {
      * Return every entry that matches the given path, in registration
      * order. The dispatch loop iterates this list; nested `setNext`
      * re-entries resume from a later index in the same list.
+     *
+     * `method`, when provided, is the request HTTP method. Routers
+     * MAY use it to filter at lookup time (e.g. method-bucketed
+     * tries) — but the App's dispatch loop still runs its own
+     * method check on every returned match, so a router that
+     * ignores `method` and emits more candidates than necessary
+     * stays correct, just not optimally fast.
+     *
+     * When the request method is `OPTIONS` (auto-Allow surface) or
+     * `HEAD` (falls through to GET), method-aware routers should
+     * widen their emission to cover those cases — see the OPTIONS /
+     * HEAD handling notes on `TrieRouter` for the canonical
+     * implementation.
      */
-    lookup(path: string): readonly RouteMatch<T>[];
+    lookup(path: string, method?: string): readonly RouteMatch<T>[];
 
     /**
      * Optional: every registered entry in registration order.

--- a/test/unit/app/clone.spec.ts
+++ b/test/unit/app/clone.spec.ts
@@ -35,10 +35,6 @@ class BrandedRouter implements IRouter<RouteEntry> {
         return this.inner.lookup(path);
     }
 
-    get routes(): readonly Route<RouteEntry>[] {
-        return this.inner.routes;
-    }
-
     clone(): IRouter<RouteEntry> {
         BrandedRouter.clones += 1;
         return new BrandedRouter();

--- a/test/unit/router/compliance.spec.ts
+++ b/test/unit/router/compliance.spec.ts
@@ -164,21 +164,22 @@ describe.each(Object.entries(resolvers))('resolver compliance: %s', (_name, fact
     });
 
     it('clone() returns a fresh empty router of the same shape', () => {
-        // IRouter.clone()'s contract: a fresh, **empty** router. Verifies
-        // App.install() / App.clone() can use it to preserve the router
-        // family without inheriting the parent's entries.
-        //
-        // Both built-in routers (LinearRouter / TrieRouter) implement
-        // the optional `routes` field; this test asserts on it via `!`
-        // because the field is optional on the IRouter contract (custom
-        // aggregated routers may discard the original entries).
+        // IRouter.clone()'s contract: a fresh, **empty** router.
+        // Verified observationally — register a route on the original,
+        // then ensure the clone returns no matches for it. Avoids
+        // depending on `IRouter.routes` (now optional on the
+        // contract; not implemented by the built-in routers anymore).
         const router = factory();
-        const beforeLen = router.routes!.length;
+        router.add({
+            path: '/users',
+            method: 'GET',
+            data: { type: 'handler', dummy: true } as never,
+        });
+        expect(router.lookup('/users', 'GET').length).toBeGreaterThan(0);
+
         const cloned = router.clone();
-        expect(cloned.routes!.length).toBe(0);
-        // Original is unchanged.
-        expect(router.routes!.length).toBe(beforeLen);
-        // The clone is a distinct instance.
+        expect(cloned.lookup('/users', 'GET').length).toBe(0);
+        // Distinct instance.
         expect(cloned).not.toBe(router);
     });
 });

--- a/test/unit/router/generic.spec.ts
+++ b/test/unit/router/generic.spec.ts
@@ -106,6 +106,9 @@ describe.each(Object.entries(resolvers))('IRouter<MyData> generic — %s', (_nam
     });
 
     it('clone() returns an empty router of the same shape', () => {
+        // Asserted observationally via `lookup` — `IRouter.routes`
+        // is optional on the contract (not implemented by the
+        // built-in routers post Plan 019).
         const router = factory();
         router.add({
             path: '/x',
@@ -114,15 +117,16 @@ describe.each(Object.entries(resolvers))('IRouter<MyData> generic — %s', (_nam
         });
 
         const cloned = router.clone();
-        expect(cloned.routes).toHaveLength(0);
+        expect(cloned.lookup('/x', MethodName.GET)).toHaveLength(0);
         // Original retained.
-        expect(router.routes).toHaveLength(1);
+        expect(router.lookup('/x', MethodName.GET)).toHaveLength(1);
         // Adding to clone does not bleed back.
         cloned.add({
             path: '/y',
             method: MethodName.GET,
             data: { name: 'b', tag: 2 },
         });
-        expect(router.routes).toHaveLength(1);
+        expect(router.lookup('/y', MethodName.GET)).toHaveLength(0);
+        expect(cloned.lookup('/y', MethodName.GET)).toHaveLength(1);
     });
 });

--- a/test/unit/router/trie-method-bucketing.spec.ts
+++ b/test/unit/router/trie-method-bucketing.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+    App,
+    LruCache,
+    TrieRouter,
+    defineCoreHandler,
+} from '../../../src';
+import type { RouteEntry } from '../../../src/app/types';
+import { createTestRequest } from '../../helpers';
+
+/**
+ * T4 — per-node method bucketing on TrieRouter.
+ *
+ * Each leaf node now stores its exact-match and splat-terminated
+ * routes in `Record<method, IndexedRoute[]>` instead of a flat
+ * list. Lookup emits only the relevant buckets for the request
+ * method (`'' | <method>` for normal requests; `'' | HEAD | GET`
+ * for HEAD; every bucket for OPTIONS so `event.methodsAllowed`
+ * still populates).
+ *
+ * Middleware (`prefixRoutes`) stays method-agnostic.
+ */
+describe('TrieRouter — method bucketing (T4)', () => {
+    it('same path, different methods: each fires only its handler', async () => {
+        const app = new App({ router: new TrieRouter<RouteEntry>() });
+        app.get('/users', defineCoreHandler(() => 'list'));
+        app.post('/users', defineCoreHandler(() => 'created'));
+
+        const get = await app.fetch(createTestRequest('/users'));
+        expect(await get.text()).toBe('list');
+
+        const post = await app.fetch(createTestRequest('/users', { method: 'POST' }));
+        expect(await post.text()).toBe('created');
+    });
+
+    it('middleware fires for both methods at the same path', async () => {
+        const app = new App({ router: new TrieRouter<RouteEntry>() });
+        const fired: string[] = [];
+
+        app.use('/users', defineCoreHandler(async (event) => {
+            fired.push(event.method);
+            return event.next();
+        }));
+        app.get('/users', defineCoreHandler(() => 'list'));
+        app.post('/users', defineCoreHandler(() => 'created'));
+
+        await app.fetch(createTestRequest('/users'));
+        await app.fetch(createTestRequest('/users', { method: 'POST' }));
+
+        expect(fired).toEqual(['GET', 'POST']);
+    });
+
+    it('OPTIONS sees every registered method (auto-Allow header)', async () => {
+        const app = new App({ router: new TrieRouter<RouteEntry>() });
+        app.get('/items', defineCoreHandler(() => 'list'));
+        app.post('/items', defineCoreHandler(() => 'created'));
+        app.delete('/items', defineCoreHandler(() => 'deleted'));
+
+        const res = await app.fetch(createTestRequest('/items', { method: 'OPTIONS' }));
+        expect(res.status).toBe(200);
+        const allow = (res.headers.get('allow') ?? '').split(',').map((s) => s.trim()).sort();
+        // HEAD is implicitly allowed when GET is present. OPTIONS
+        // itself isn't included in the Allow header (matches the
+        // existing OPTIONS auto-Allow behaviour in methods.spec.ts).
+        expect(allow).toEqual(['DELETE', 'GET', 'HEAD', 'POST']);
+    });
+
+    it('HEAD falls through to a GET handler', async () => {
+        const app = new App({ router: new TrieRouter<RouteEntry>() });
+        app.get('/users', defineCoreHandler(() => 'list'));
+
+        const res = await app.fetch(createTestRequest('/users', { method: 'HEAD' }));
+        expect(res.status).toBe(200);
+    });
+
+    it('splat with method binding only fires for that method', async () => {
+        // Named splat (`*rest`) — bare `*` isn't accepted by
+        // path-to-regexp v8, but the trie still buckets named splats
+        // per method. This catches the per-bucket emission for
+        // `splatRoutes`.
+        const app = new App({ router: new TrieRouter<RouteEntry>() });
+        app.get('/files/*rest', defineCoreHandler(() => 'get-files'));
+        app.post('/files/*rest', defineCoreHandler(() => 'post-files'));
+
+        expect(await (await app.fetch(createTestRequest('/files/a/b'))).text()).toBe('get-files');
+        expect(await (await app.fetch(createTestRequest('/files/a/b', { method: 'POST' }))).text())
+            .toBe('post-files');
+    });
+
+    it('cache differentiates entries per method', async () => {
+        // With the cache enabled, GET /users and POST /users must
+        // not share a cached candidate set — they would emit
+        // different handler buckets after T4.
+        const app = new App({ router: new TrieRouter<RouteEntry>({ cache: new LruCache() }) });
+        app.get('/users', defineCoreHandler(() => 'list'));
+        app.post('/users', defineCoreHandler(() => 'created'));
+
+        // First call warms the cache for GET.
+        expect(await (await app.fetch(createTestRequest('/users'))).text()).toBe('list');
+        // POST must NOT pick up the cached GET match.
+        expect(await (await app.fetch(createTestRequest('/users', { method: 'POST' }))).text())
+            .toBe('created');
+    });
+});

--- a/test/unit/router/trie-syntax.spec.ts
+++ b/test/unit/router/trie-syntax.spec.ts
@@ -112,6 +112,56 @@ describe('TrieRouter — Phase 2 syntax', () => {
         });
     });
 
+    describe('audit — regressions caught during review', () => {
+        it('splat-not-last falls through to universal (does not silently drop trailing segments)', async () => {
+            // `/files/*rest/extra` requires `/extra` after the splat-
+            // captured segments. The trie's `insertIntoTrie` would
+            // happily push the route into `splatRoutes` at depth 1
+            // and silently drop `/extra`. After Phase 2 dropped the
+            // `matcher.exec` confirm pass, the only safety net is
+            // making the parser refuse such paths so they fall back
+            // to path-to-regexp via the universal bucket.
+            const a = app();
+            a.get('/files/*rest/extra', defineCoreHandler(() => 'matched'));
+
+            // Without `/extra` → 404 (path-to-regexp template
+            // requires the trailing literal).
+            expect((await a.fetch(createTestRequest('/files/abc'))).status).toBe(404);
+            // With `/extra` → matches.
+            expect((await a.fetch(createTestRequest('/files/abc/extra'))).status).toBe(200);
+        });
+
+        it('exact-match handler at "/" does not match every path', async () => {
+            // `app.get('/', h)` is exact — it must reject `/users`
+            // and friends. Bypassing the trie at registration and
+            // omitting the matcher would silently make this handler
+            // serve every request.
+            const a = app();
+            a.get('/', defineCoreHandler(() => 'root'));
+
+            expect((await a.fetch(createTestRequest('/'))).status).toBe(200);
+            expect((await a.fetch(createTestRequest('/users'))).status).toBe(404);
+            expect((await a.fetch(createTestRequest('/foo/bar'))).status).toBe(404);
+        });
+
+        it('splat-terminated mounted app sees full request via mountPath', async () => {
+            // `app.use('/files/*rest', child)` matches every path
+            // under `/files`. `match.path` (used by the dispatcher
+            // to strip mount prefix) must reflect the full matched
+            // request — pre-Phase-2 this was the path-to-regexp
+            // `output.path` (the entire matched portion); post-
+            // Phase-2 the trie should compute the same.
+            const inner = new App({ router: new TrieRouter<RouteEntry>() });
+            inner.get('/', defineCoreHandler((event) => event.mountPath));
+
+            const outer = new App({ router: new TrieRouter<RouteEntry>() });
+            outer.use('/files/*rest', inner);
+
+            const res = await outer.fetch(createTestRequest('/files/a/b/c'));
+            expect(await res.text()).toBe('/files/a/b/c');
+        });
+    });
+
     describe('T6 — trie-native parser', () => {
         it('treats trailing slash as significant (strict mode)', async () => {
             const a = app();

--- a/test/unit/router/trie-syntax.spec.ts
+++ b/test/unit/router/trie-syntax.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+    App,
+    TrieRouter,
+    defineCoreHandler,
+} from '../../../src';
+import type { RouteEntry } from '../../../src/app/types';
+import { createTestRequest } from '../../helpers';
+
+/**
+ * Phase 2 — TrieRouter owns its syntax surface end-to-end. The
+ * trie's own parser handles the routup vocabulary (static, `:name`,
+ * `:name?`, `{...}`, `*`, `*name`); param extraction comes from a
+ * pre-built `paramsIndexMap` walked against the request's segments
+ * (no `matcher.exec` per match, no path-to-regexp dependency).
+ *
+ * Paths the trie parser doesn't handle (regex constraints, compound
+ * segments like `/files/:n.ext`, escape sequences) fall back to the
+ * universal bucket which still uses path-to-regexp — covered by
+ * `compliance.spec.ts` against both routers.
+ */
+describe('TrieRouter — Phase 2 syntax', () => {
+    function app() {
+        return new App({ router: new TrieRouter<RouteEntry>() });
+    }
+
+    describe('T2 — optional params (`:name?`)', () => {
+        it('matches with and without the optional param', async () => {
+            const a = app();
+            a.get('/users/:id?', defineCoreHandler((event) => `id=${event.params.id ?? 'none'}`));
+
+            expect(await (await a.fetch(createTestRequest('/users'))).text()).toBe('id=none');
+            expect(await (await a.fetch(createTestRequest('/users/42'))).text()).toBe('id=42');
+        });
+    });
+
+    describe('T2 — optional groups (`{/segment}`)', () => {
+        it('matches with and without the group', async () => {
+            const a = app();
+            a.get('/users{/edit}', defineCoreHandler(() => 'matched'));
+
+            expect((await a.fetch(createTestRequest('/users'))).status).toBe(200);
+            expect((await a.fetch(createTestRequest('/users/edit'))).status).toBe(200);
+            expect((await a.fetch(createTestRequest('/users/other'))).status).toBe(404);
+        });
+
+        it('expands param inside group', async () => {
+            const a = app();
+            a.get('/users{/:id}', defineCoreHandler((event) => `id=${event.params.id ?? 'none'}`));
+
+            expect(await (await a.fetch(createTestRequest('/users'))).text()).toBe('id=none');
+            expect(await (await a.fetch(createTestRequest('/users/42'))).text()).toBe('id=42');
+        });
+    });
+
+    describe('T3 — ParamsIndexMap-style extraction', () => {
+        it('extracts a single param', async () => {
+            const a = app();
+            a.get('/users/:id', defineCoreHandler((event) => String(event.params.id)));
+
+            expect(await (await a.fetch(createTestRequest('/users/42'))).text()).toBe('42');
+        });
+
+        it('extracts multiple params', async () => {
+            const a = app();
+            a.get(
+                '/orgs/:org/repos/:repo',
+                defineCoreHandler((event) => `${event.params.org}:${event.params.repo}`),
+            );
+
+            expect(await (await a.fetch(createTestRequest('/orgs/acme/repos/widgets'))).text())
+                .toBe('acme:widgets');
+        });
+
+        it('captures named splat as the joined remainder', async () => {
+            const a = app();
+            a.get('/static/*file', defineCoreHandler((event) => String(event.params.file)));
+
+            expect(await (await a.fetch(createTestRequest('/static/css/main.css'))).text())
+                .toBe('css/main.css');
+        });
+
+        it('captures bare splat as `*`', async () => {
+            const a = app();
+            a.get('/proxy/*', defineCoreHandler((event) => String(event.params['*'])));
+
+            expect(await (await a.fetch(createTestRequest('/proxy/api/users'))).text())
+                .toBe('api/users');
+        });
+
+        it('decodes URL-encoded param values', async () => {
+            const a = app();
+            a.get('/users/:name', defineCoreHandler((event) => String(event.params.name)));
+
+            // %20 → space
+            const res = await a.fetch(createTestRequest('/users/john%20doe'));
+            expect(await res.text()).toBe('john doe');
+        });
+
+        it('returns the matched prefix as `event.mountPath` for nested apps', async () => {
+            const inner = new App({ router: new TrieRouter<RouteEntry>() });
+            inner.get('/items', defineCoreHandler((event) => event.mountPath));
+
+            const outer = new App({ router: new TrieRouter<RouteEntry>() });
+            outer.use('/api/:version', inner);
+
+            // The trie computes `match.path` = `/api/v1` from the request
+            // segments and the variant's matchDepth (no matcher.exec).
+            // App's dispatch then strips that prefix when descending.
+            const res = await outer.fetch(createTestRequest('/api/v1/items'));
+            expect(await res.text()).toBe('/api/v1');
+        });
+    });
+
+    describe('T6 — trie-native parser', () => {
+        it('treats trailing slash as significant (strict mode)', async () => {
+            const a = app();
+            a.get('/users', defineCoreHandler(() => 'no-slash'));
+
+            // The request `/users/` has an extra trailing segment
+            // (after splitting on `/`, the trailing empty string is
+            // dropped by `parseRequestPath` — so they collapse to
+            // the same lookup key. Document the actual behaviour.)
+            expect((await a.fetch(createTestRequest('/users'))).status).toBe(200);
+            expect((await a.fetch(createTestRequest('/users/'))).status).toBe(200);
+        });
+
+        it('falls back to universal bucket on compound segments', async () => {
+            // `/files/:name.ext` is a compound segment (param +
+            // literal in the same path segment) — path-to-regexp v8
+            // supports it but the trie's own parser doesn't. The
+            // route must still work via the universal-bucket
+            // fallback.
+            const a = app();
+            a.get('/files/:name.ext', defineCoreHandler((event) => String(event.params.name)));
+
+            expect(await (await a.fetch(createTestRequest('/files/report.ext'))).text())
+                .toBe('report');
+            // Wrong literal suffix → no match (proves the universal
+            // matcher's path-to-regexp template applied).
+            expect((await a.fetch(createTestRequest('/files/report.txt'))).status).toBe(404);
+        });
+    });
+});

--- a/test/unit/router/trie-syntax.spec.ts
+++ b/test/unit/router/trie-syntax.spec.ts
@@ -112,6 +112,67 @@ describe('TrieRouter — Phase 2 syntax', () => {
         });
     });
 
+    describe('audit — review-round 2', () => {
+        it('expanded prefix variants prefer the most specific match (greatest matchDepth)', async () => {
+            // `use('/api/:version?', child)` expands to `/api` and
+            // `/api/:version`. For request `/api/v1`, both match
+            // structurally — the dedup must keep the *longer* one
+            // so `params.version === 'v1'` and `event.mountPath ===
+            // '/api/v1'`. Picking the shorter variant blindly would
+            // lose params.
+            const inner = new App({ router: new TrieRouter<RouteEntry>() });
+            inner.get('/', defineCoreHandler((event) => `version=${event.params.version ?? 'none'}`));
+
+            const outer = new App({ router: new TrieRouter<RouteEntry>() });
+            outer.use('/api/:version?', inner);
+
+            expect(await (await outer.fetch(createTestRequest('/api/v1'))).text())
+                .toBe('version=v1');
+            expect(await (await outer.fetch(createTestRequest('/api'))).text())
+                .toBe('version=none');
+        });
+
+        it('rejects literal text following a `}` group close (compound — universal bucket)', async () => {
+            // `/a{/b}c` is compound syntax (literal `c` adjacent to
+            // an optional group). The trie parser can't represent
+            // it cleanly; without the post-`}` validation it
+            // silently rewrote into `/a/c` + `/a/b/c`, which is
+            // wrong. Falling to the universal bucket lets path-to-
+            // regexp speak with authority.
+            const a = app();
+            a.get('/a{/b}c', defineCoreHandler(() => 'matched'));
+
+            // path-to-regexp v8 interprets `/a{/b}c` as `/a/c` or
+            // `/a/b/c` (the literal `c` is consumed by the group's
+            // tail). The trie should NOT promiscuously match
+            // anything else — `/a/x` must 404.
+            expect((await a.fetch(createTestRequest('/a/x'))).status).toBe(404);
+        });
+
+        it('falls back to universal bucket above MAX_VARIANTS', async () => {
+            // 5 optional groups → 32 variants, exceeds the parser's
+            // cap of 16. The route should still register and dispatch
+            // correctly via the universal-bucket fallback.
+            const a = app();
+            a.get('/a{/b}{/c}{/d}{/e}{/f}', defineCoreHandler(() => 'capped'));
+
+            expect((await a.fetch(createTestRequest('/a'))).status).toBe(200);
+            expect((await a.fetch(createTestRequest('/a/b/c/d/e/f'))).status).toBe(200);
+        });
+
+        it('falls back to the raw segment value on malformed URL encoding', async () => {
+            // `decodeURIComponent('%2')` throws `URIError`. The
+            // try/catch in `decodeOrRaw` returns the raw segment so
+            // the route still matches without crashing.
+            const a = app();
+            a.get('/users/:name', defineCoreHandler((event) => String(event.params.name)));
+
+            const res = await a.fetch(createTestRequest('/users/bad%2'));
+            expect(res.status).toBe(200);
+            expect(await res.text()).toBe('bad%2');
+        });
+    });
+
     describe('audit — regressions caught during review', () => {
         it('splat-not-last falls through to universal (does not silently drop trailing segments)', async () => {
             // `/files/*rest/extra` requires `/extra` after the splat-
@@ -163,14 +224,16 @@ describe('TrieRouter — Phase 2 syntax', () => {
     });
 
     describe('T6 — trie-native parser', () => {
-        it('treats trailing slash as significant (strict mode)', async () => {
+        it('collapses trailing slash (parseRequestPath drops empty trailing segments)', async () => {
             const a = app();
-            a.get('/users', defineCoreHandler(() => 'no-slash'));
+            a.get('/users', defineCoreHandler(() => 'matched'));
 
-            // The request `/users/` has an extra trailing segment
-            // (after splitting on `/`, the trailing empty string is
-            // dropped by `parseRequestPath` — so they collapse to
-            // the same lookup key. Document the actual behaviour.)
+            // `parseRequestPath` splits on `/` and drops empty
+            // segments, so `/users` and `/users/` collapse to the
+            // same `['users']` lookup. Trailing slashes are NOT
+            // significant — both match. (LinearRouter shows the
+            // same behaviour; documented divergence from path-to-
+            // regexp's strict mode.)
             expect((await a.fetch(createTestRequest('/users'))).status).toBe(200);
             expect((await a.fetch(createTestRequest('/users/'))).status).toBe(200);
         });


### PR DESCRIPTION
## Summary

Combined PR — Plan 010 T4 + Phase 2 (T2 + T3 + T6) per `.agents/plans/015-roadmap.md` "Suggested cadence."

After this PR, `TrieRouter` owns its full syntax surface end-to-end:
- Per-leaf method bucketing — lookup narrows to the request method's buckets instead of emitting every entry and letting the dispatcher filter (T4).
- Trie-native parser with `:name?` / `{...}` expansion at registration (T2 + T6).
- ParamsIndexMap-driven extraction — params come from `segments[depth]` reads + `decodeURIComponent`; no `matcher.exec` per match on the trie hot path (T3).
- `path-to-regexp` is still used for the universal-bucket fallback (compound segments `/files/:n.ext`, escape sequences, anything the parser doesn't recognise) so correctness is preserved.

Two commits, each independently bench-able:

1. **`e3a28a8`** — T4: per-node method bucketing. `IRouter.lookup` gains an optional `method?` arg; `TrieRouter` uses it. HEAD widens to GET, OPTIONS / no-method widens to all buckets so `event.methodsAllowed` populates. Cache key now `${method}\\t${path}`.
2. **`b9e665c`** — Phase 2: parser, expansion, paramsIndexMap. Trie's `lookup()` no longer calls `matcher.exec` for trie-walked routes.

## Test plan

- [x] All 376 unit tests pass (49 spec files; 17 new tests across two new spec files: `trie-method-bucketing.spec.ts` for T4 and `trie-syntax.spec.ts` for Phase 2)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only pre-existing `benchmark/run.mjs` console-statement warnings)
- [ ] Re-run autocannon against trie: expected ~0–2% from T4, sub-1% from Phase 2 (per plan 015 — wins are bundle / dependency / cold-start, not steady-state CPU)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Trie-native path parser with optional params (`:name?`) and optional segment groups (`{/segment}`)
  - Method-aware routing with improved HEAD/OPTIONS handling

* **Bug Fixes**
  - Route lookup now considers request method and isolates cached candidates by method
  - More reliable param/splat capture, mountPath handling, trailing-slash normalization, and safe fallbacks for complex patterns

* **Tests**
  - New and updated unit suites covering trie syntax and per-method routing behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/routup/routup/pull/905)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->