### PR TITLE
refactor(router)!: drop optional `routes` from the IRouter contract

### DIFF
--- a/docs/src/guide/custom-router.md
+++ b/docs/src/guide/custom-router.md
@@ -9,8 +9,7 @@ The router contract is the `IRouter<T>` interface, generic over the per-route da
 ```typescript
 interface IRouter<T extends ObjectLiteral = ObjectLiteral> {
     add(route: Route<T>): void;
-    lookup(path: string): readonly RouteMatch<T>[];
-    readonly routes: readonly Route<T>[];
+    lookup(path: string, method?: string): readonly RouteMatch<T>[];
     clone(): IRouter<T>;
 }
 
@@ -37,7 +36,11 @@ Custom implementations must honor a single rule:
 - `route.method !== undefined` → match the path **exactly** (the route is method-bound, e.g. `app.get('/users', …)`).
 - `route.method === undefined` → match by **prefix** (middleware, nested app).
 
-Method matching against the request's HTTP method stays at the dispatch-loop call site — your router only decides whether the *path* qualifies.
+Method matching against the request's HTTP method stays at the dispatch-loop call site — your router only decides whether the *path* qualifies. (Method-aware routers like `TrieRouter` may use the optional `method` argument to narrow at lookup time as a perf optimisation.)
+
+### No enumeration on the contract
+
+`IRouter<T>` deliberately has no `routes` accessor. `App` keeps its own list of registered routes and uses that for cloning, plugin sub-app mounting, and option cascading — your router never has to expose its internal storage. This frees future router implementations (aggregated regex, freeze-after-first-match) to discard the original entries once they've built their lookup structure.
 
 ### Registration order
 
@@ -69,10 +72,6 @@ class CountingRouter implements IRouter<RouteEntry> {
     lookup(path: string): readonly RouteMatch<RouteEntry>[] {
         this.lookups += 1;
         return this.inner.lookup(path);
-    }
-
-    get routes() {
-        return this.inner.routes;
     }
 
     clone(): IRouter<RouteEntry> {

--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -153,12 +153,11 @@ export class App implements IApp {
     /**
      * Every route registered on this App, in registration order.
      *
-     * Owning the list at the App level (rather than reading it back
-     * from `this.router.routes`) lets us narrow the `IRouter`
-     * contract — `routes` is now optional on the interface — and
-     * gives `setRouter` a single source of truth to replay onto a
-     * swap-in router. Routes are pushed alongside every
-     * `this.router.add()` via the `register` helper.
+     * App owns the canonical list — the `IRouter` contract has no
+     * `routes` field, so cascades / clones / `setRouter` replay
+     * read from here instead of asking the router. Routes are
+     * pushed alongside every `this.router.add()` via the `register`
+     * helper.
      *
      * @protected
      */
@@ -184,8 +183,8 @@ export class App implements IApp {
     /**
      * Register a route with the active router and record it on the
      * App so we can replay it onto a different router later (see
-     * `setRouter`) and so cascades / clones don't depend on
-     * `IRouter.routes`.
+     * `setRouter`) and so cascades / clones have a source of truth
+     * independent of the router instance.
      *
      * @protected
      */

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -71,20 +71,6 @@ export interface IRouter<T extends ObjectLiteral = ObjectLiteral> {
     lookup(path: string, method?: string): readonly RouteMatch<T>[];
 
     /**
-     * Optional: every registered entry in registration order.
-     *
-     * `App` keeps its own copy of every route it registers, so it
-     * never has to call back into the router for enumeration. This
-     * field is kept on the contract as a convenience for direct
-     * router consumers (and the built-in routers happen to maintain
-     * it for free since they hold the list anyway), but custom
-     * routers — including future aggregated/compiled implementations
-     * that may discard the original entries after building their
-     * lookup structure — are free to omit it.
-     */
-    readonly routes?: readonly Route<T>[];
-
-    /**
      * Return a fresh, **empty** router of the same shape — same class
      * for leaf implementations; composable wrappers should recursively
      * clone their inner router. Used by `App.install()` and

--- a/test/unit/app/set-router.spec.ts
+++ b/test/unit/app/set-router.spec.ts
@@ -35,24 +35,27 @@ describe('App.setRouter', () => {
         expect(await (await app.fetch(createTestRequest('/after'))).text()).toBe('after');
     });
 
-    it('IRouter.routes is optional — App does not depend on it', async () => {
-        // A minimal router that does NOT implement the optional `routes`
-        // field — proves App can live without it.
-        class NoEnumerationRouter implements Required<Pick<TrieRouter<RouteEntry>, 'add' | 'lookup' | 'clone'>> {
+    it('IRouter contract has no enumeration — App owns the canonical route list', async () => {
+        // A minimal router that implements only the contract
+        // (`add` / `lookup` / `clone`). Proves App's clone cascade
+        // and `extendOptions` propagation work without ever asking
+        // the router to enumerate its entries — App's own
+        // `_routes` is the single source of truth.
+        class MinimalRouter implements Pick<TrieRouter<RouteEntry>, 'add' | 'lookup' | 'clone'> {
             private inner = new LinearRouter<RouteEntry>();
             add(route: Route<RouteEntry>) { this.inner.add(route); }
             lookup(p: string) { return this.inner.lookup(p); }
-            clone() { return new NoEnumerationRouter(); }
+            clone() { return new MinimalRouter(); }
         }
 
-        const app = new App({ router: new NoEnumerationRouter() });
+        const app = new App({ router: new MinimalRouter() });
         app.get('/x', defineCoreHandler(() => 'ok'));
 
         const res = await app.fetch(createTestRequest('/x'));
         expect(await res.text()).toBe('ok');
 
-        // clone() and extendOptions cascade should both work without
-        // calling into the router's enumeration.
+        // clone() rebuilds entries on the cloned router from
+        // App._routes — no router-side enumeration.
         const cloned = app.clone();
         const res2 = await cloned.fetch(createTestRequest('/x'));
         expect(await res2.text()).toBe('ok');

--- a/test/unit/router/generic.spec.ts
+++ b/test/unit/router/generic.spec.ts
@@ -106,9 +106,9 @@ describe.each(Object.entries(resolvers))('IRouter<MyData> generic — %s', (_nam
     });
 
     it('clone() returns an empty router of the same shape', () => {
-        // Asserted observationally via `lookup` — `IRouter.routes`
-        // is optional on the contract (not implemented by the
-        // built-in routers post Plan 019).
+        // Asserted observationally via `lookup` — the IRouter
+        // contract has no `routes` field, so behaviour is the
+        // only honest thing to assert against.
         const router = factory();
         router.add({
             path: '/x',


### PR DESCRIPTION
## Summary

`IRouter.routes` was already optional after Plan 019 — App owned the canonical list and only ever used the field for clone / cascade fallback (both since rewritten to read from `App._routes`). The trie audit removed both built-in routers' implementations of it. Removing the field from the interface itself tightens the contract: custom routers no longer have to claim they can enumerate when they can't.

The new contract:

```ts
interface IRouter<T extends ObjectLiteral = ObjectLiteral> {
    add(route: Route<T>): void;
    lookup(path: string, method?: string): readonly RouteMatch<T>[];
    clone(): IRouter<T>;
}
```

This matches Hono's router contract shape and unblocks future aggregated/compiled routers (RegExpRouter-style, freeze-after-first-match) that discard original entries once their lookup structure is built.

## Changes

- `IRouter<T>`: drops the `routes?` field.
- `App` doc comments stop referencing `IRouter.routes`.
- `set-router.spec.ts`: test renamed; the `MinimalRouter` fixture now matches the (truly minimal) interface.
- `generic.spec.ts`: comment updated.
- Custom-router guide: interface block updated, new "No enumeration on the contract" section explaining the design choice, counting-router example loses its `routes` getter.

## Test plan

- [x] All 383 unit tests pass
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only pre-existing benchmark warnings)
- [x] No production code reads or implements `IRouter.routes` anywhere — pure contract narrowing