### PR TITLE
feat(router): add SmartRouter — auto-selects Linear vs Trie

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,5 @@
 export * from './linear/index.ts';
+export * from './smart/index.ts';
 export * from './trie/index.ts';
 export * from './types.ts';
 export * from './utils.ts';

--- a/src/router/smart/index.ts
+++ b/src/router/smart/index.ts
@@ -1,0 +1,1 @@
+export * from './module.ts';

--- a/src/router/smart/module.ts
+++ b/src/router/smart/module.ts
@@ -1,0 +1,103 @@
+import type { ICache } from '../../cache/index.ts';
+import type { ObjectLiteral, Route, RouteMatch } from '../../types.ts';
+import { LinearRouter } from '../linear/index.ts';
+import { TrieRouter } from '../trie/index.ts';
+import type { BaseRouterOptions, IRouter } from '../types.ts';
+
+/**
+ * Default crossover. Empirically `LinearRouter` wins for small route
+ * counts (no per-request trie walk overhead, no static-spine setup);
+ * `TrieRouter` wins past ~30 entries on typical workloads. Override
+ * via `SmartRouterOptions.threshold` when a benchmark says otherwise
+ * for your route shape.
+ */
+const DEFAULT_THRESHOLD = 30;
+
+export type SmartRouterOptions<T extends ObjectLiteral = ObjectLiteral> = BaseRouterOptions<T> & {
+    /**
+         * Route count at or above which `SmartRouter` switches from
+         * `LinearRouter` (faster at small N) to `TrieRouter` (faster
+         * at large N). Default `30`.
+         */
+    threshold?: number;
+};
+
+/**
+ * Auto-selecting router. Accumulates registered routes in a pending
+ * buffer; on the first `lookup()` call, picks `LinearRouter` or
+ * `TrieRouter` based on the registered route count and replays the
+ * pending list onto the chosen inner router. Every subsequent call
+ * — `add`, `lookup`, `clone` — forwards to the inner.
+ *
+ * Use this when you don't want to commit to a router family up-front
+ * (e.g. a library that registers a variable number of routes
+ * depending on configuration). For known workloads, prefer the
+ * concrete router — `SmartRouter` adds one indirection per call.
+ *
+ * Inspired by Hono's `SmartRouter` (which auto-selects across more
+ * candidates including `RegExpRouter`); ours covers the only choice
+ * that matters in routup today: linear-vs-trie at the registration-
+ * size crossover.
+ */
+export class SmartRouter<T extends ObjectLiteral = ObjectLiteral> implements IRouter<T> {
+    protected inner?: IRouter<T>;
+
+    protected pending: Route<T>[] = [];
+
+    protected readonly threshold: number;
+
+    /**
+     * Cache handed off to whichever inner router gets chosen. Stays
+     * `undefined` if the user didn't configure one.
+     */
+    protected readonly cache?: ICache<readonly RouteMatch<T>[]>;
+
+    constructor(options: SmartRouterOptions<T> = {}) {
+        this.threshold = options.threshold ?? DEFAULT_THRESHOLD;
+        this.cache = options.cache;
+    }
+
+    add(route: Route<T>): void {
+        if (this.inner) {
+            this.inner.add(route);
+            return;
+        }
+        this.pending.push(route);
+    }
+
+    lookup(path: string, method?: string): readonly RouteMatch<T>[] {
+        if (!this.inner) {
+            this.inner = this.choose();
+            for (const r of this.pending) {
+                this.inner.add(r);
+            }
+            this.pending = [];
+        }
+        return this.inner.lookup(path, method);
+    }
+
+    clone(): IRouter<T> {
+        // A fresh `SmartRouter` — uncommitted, ready to re-decide
+        // based on its own registrations. Cache *shape* is carried
+        // forward (not contents) the same way the leaf routers do
+        // it; the inner router will receive it on first lookup.
+        return new SmartRouter<T>({
+            threshold: this.threshold,
+            cache: this.cache?.clone(),
+        });
+    }
+
+    /**
+     * Pick the inner router based on the registered route count.
+     * `LinearRouter` for tiny tables, `TrieRouter` past the
+     * configured threshold.
+     *
+     * @protected
+     */
+    protected choose(): IRouter<T> {
+        if (this.pending.length < this.threshold) {
+            return new LinearRouter<T>({ cache: this.cache });
+        }
+        return new TrieRouter<T>({ cache: this.cache });
+    }
+}

--- a/test/unit/router/smart.spec.ts
+++ b/test/unit/router/smart.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+    App,
+    LinearRouter,
+    LruCache,
+    SmartRouter,
+    TrieRouter,
+    defineCoreHandler,
+} from '../../../src';
+import type { RouteEntry } from '../../../src/app/types';
+import { createTestRequest } from '../../helpers';
+
+/**
+ * `SmartRouter` accumulates registered routes in a pending buffer
+ * until the first `lookup()`, then picks `LinearRouter` (tiny route
+ * table) or `TrieRouter` (past threshold) and replays the pending
+ * list onto it. Subsequent `add` / `lookup` / `clone` forward.
+ */
+describe('SmartRouter', () => {
+    // The chosen inner router is a `protected` field — cast through
+    // `unknown` to read it. Production code shouldn't depend on the
+    // choice, only tests do.
+    function inner(r: SmartRouter<RouteEntry>): unknown {
+        return (r as unknown as { inner?: unknown }).inner;
+    }
+
+    it('picks LinearRouter under the threshold', async () => {
+        const router = new SmartRouter<RouteEntry>({ threshold: 5 });
+        const app = new App({ router });
+        for (let i = 0; i < 3; i++) {
+            app.get(`/r${i}`, defineCoreHandler(() => `r${i}`));
+        }
+
+        // First fetch triggers the choice.
+        const res = await app.fetch(createTestRequest('/r0'));
+        expect(await res.text()).toBe('r0');
+        expect(inner(router)).toBeInstanceOf(LinearRouter);
+    });
+
+    it('picks TrieRouter at or above the threshold', async () => {
+        const router = new SmartRouter<RouteEntry>({ threshold: 5 });
+        const app = new App({ router });
+        for (let i = 0; i < 5; i++) {
+            app.get(`/r${i}`, defineCoreHandler(() => `r${i}`));
+        }
+
+        const res = await app.fetch(createTestRequest('/r0'));
+        expect(await res.text()).toBe('r0');
+        expect(inner(router)).toBeInstanceOf(TrieRouter);
+    });
+
+    it('forwards routes registered after the first lookup to the chosen inner', async () => {
+        const router = new SmartRouter<RouteEntry>({ threshold: 5 });
+        const app = new App({ router });
+        app.get('/before', defineCoreHandler(() => 'before'));
+
+        // First lookup → SmartRouter commits to LinearRouter.
+        expect(await (await app.fetch(createTestRequest('/before'))).text()).toBe('before');
+
+        // Late registration goes straight to the inner.
+        app.get('/after', defineCoreHandler(() => 'after'));
+        expect(await (await app.fetch(createTestRequest('/after'))).text()).toBe('after');
+    });
+
+    it('uses the configured cache on the chosen inner router', async () => {
+        // Track whether `set` was called on the user-supplied cache —
+        // proves the cache reference was handed off to the inner
+        // router (which is the only thing that calls `set`).
+        let setCalls = 0;
+        const cache = new LruCache<readonly any[]>();
+        const originalSet = cache.set.bind(cache);
+        cache.set = (k, v) => { setCalls++; originalSet(k, v); };
+
+        const router = new SmartRouter<RouteEntry>({ threshold: 3, cache });
+        const app = new App({ router });
+        for (let i = 0; i < 3; i++) {
+            app.get(`/r${i}`, defineCoreHandler(() => `r${i}`));
+        }
+
+        await app.fetch(createTestRequest('/r0'));
+        expect(setCalls).toBeGreaterThan(0);
+    });
+
+    it('clone() returns a fresh, uncommitted SmartRouter', () => {
+        const router = new SmartRouter<RouteEntry>({ threshold: 5 });
+        router.add({
+            path: '/x',
+            method: 'GET',
+            data: { type: 'handler', dummy: true } as never,
+        });
+        // Force the original to choose its inner.
+        router.lookup('/x', 'GET');
+        expect(inner(router)).toBeDefined();
+
+        const cloned = router.clone() as SmartRouter<RouteEntry>;
+        // Clone hasn't decided yet — no inner until something
+        // triggers a lookup, and routes from the original do NOT
+        // carry over (matches LinearRouter / TrieRouter clone
+        // semantics).
+        expect(inner(cloned)).toBeUndefined();
+        expect(cloned.lookup('/x', 'GET').length).toBe(0);
+    });
+
+    it('default threshold defers to TrieRouter at 30+ entries', async () => {
+        const router = new SmartRouter<RouteEntry>();
+        const app = new App({ router });
+        for (let i = 0; i < 30; i++) {
+            app.get(`/r${i}`, defineCoreHandler(() => `r${i}`));
+        }
+        await app.fetch(createTestRequest('/r0'));
+        expect(inner(router)).toBeInstanceOf(TrieRouter);
+    });
+
+    it('serves correctly when no routes are registered (empty pending)', async () => {
+        const router = new SmartRouter<RouteEntry>();
+        const app = new App({ router });
+        const res = await app.fetch(createTestRequest('/anything'));
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
## Summary

Routup's third built-in router. Accumulates routes in a pending buffer; on the first \`lookup()\` call, picks \`LinearRouter\` (faster at small route counts) or \`TrieRouter\` (faster past the threshold) based on how many routes are registered, then replays them onto the chosen inner router. Subsequent calls forward.

API:
\`\`\`ts
new SmartRouter()                          // default threshold 30
new SmartRouter({ threshold: 50 })
new SmartRouter({ cache: new LruCache() })
\`\`\`

Inspired by Hono's \`SmartRouter\`. Ours wraps the only meaningful choice in routup (linear vs trie at the registration-size crossover) without introducing a new matching engine — the family stays "two leaves + one auto-selector."

Use this when you don't want to commit to a router family up-front (e.g. a library that registers a variable number of routes depending on configuration). For known workloads the concrete router avoids one indirection per call.

## Test plan

- [x] All 390 unit tests pass (7 new under \`smart.spec.ts\`)
- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [ ] No new public API beyond the \`SmartRouter\` class itself