### PR TITLE
refactor!: tighten `event.method` and `event.params` typing

### DIFF
--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -55,7 +55,7 @@ import type { Route } from '../types.ts';
  */
 function mergeMatchParams(
     event: IDispatcherEvent,
-    matchParams: Record<string, unknown>,
+    matchParams: Record<string, string | undefined>,
 ): void {
     // Cheap emptiness probe — short-circuits on the first own key.
     // `for...in` is fine here: resolver params are always plain

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,15 @@ export const MethodName = {
 
 export type MethodName = typeof MethodName[keyof typeof MethodName];
 
+/**
+ * `MethodName` plus the open-enum escape hatch for non-standard
+ * methods (`PROPFIND`, `MKCOL`, custom verbs). The `(string & {})`
+ * intersection is structurally identical to `string` but TypeScript
+ * doesn't collapse the union — so callers still get autocomplete
+ * for the canonical methods while remaining free to pass anything.
+ */
+export type MethodNameLike = MethodName | (string & {});
+
 export const HeaderName = {
     ACCEPT: 'accept',
     ACCEPT_CHARSET: 'accept-charset',

--- a/src/dispatcher/module.ts
+++ b/src/dispatcher/module.ts
@@ -9,17 +9,18 @@ import type {
 } from '../event/types.ts';
 import { toResponse } from '../response/index.ts';
 import type { AppOptions } from '../app/types.ts';
+import type { MethodNameLike } from '../constants.ts';
 import type { IDispatcherEvent } from './types.ts';
 
 
 export class DispatcherEvent implements IDispatcherEvent {
     readonly request: AppRequest;
 
-    params: Record<string, any>;
+    params: Record<string, string | undefined>;
 
     path: string;
 
-    readonly method: string;
+    readonly method: MethodNameLike;
 
     /**
      * Collected allowed methods (for OPTIONS).

--- a/src/dispatcher/types.ts
+++ b/src/dispatcher/types.ts
@@ -6,6 +6,7 @@ import type {
     NextFn,
 } from '../event/types.ts';
 import type { AppOptions } from '../app/types.ts';
+import type { MethodNameLike } from '../constants.ts';
 
 export interface IDispatcherEvent {
     /**
@@ -14,9 +15,11 @@ export interface IDispatcherEvent {
     readonly request: AppRequest;
 
     /**
-     * Route parameters extracted from the URL path pattern.
+     * Route parameters extracted from the URL path pattern. Values
+     * are `string` (or `undefined` for an optional param that
+     * didn't match).
      */
-    params: Record<string, any>;
+    params: Record<string, string | undefined>;
 
     /**
      * Current request path, adjusted relative to the mount point during router nesting.
@@ -24,9 +27,10 @@ export interface IDispatcherEvent {
     path: string;
 
     /**
-     * HTTP method (GET, POST, PUT, etc.).
+     * HTTP method (GET, POST, PUT, etc.). See `IAppEvent.method`
+     * for the open-enum typing rationale.
      */
-    readonly method: string;
+    readonly method: MethodNameLike;
 
     /**
      * Accumulated mount path from nested routers.

--- a/src/event/module.ts
+++ b/src/event/module.ts
@@ -1,4 +1,5 @@
 import type { AppOptions } from '../app/types.ts';
+import type { MethodNameLike } from '../constants.ts';
 import type {
     AppRequest,
     AppResponse,
@@ -7,9 +8,9 @@ import type {
 
 export type AppEventCreateContext = {
     request: AppRequest;
-    params: Record<string, any>;
+    params: Record<string, string | undefined>;
     path: string;
-    method: string;
+    method: MethodNameLike;
     mountPath: string;
     headers: Headers;
     searchParams: URLSearchParams;
@@ -23,11 +24,11 @@ export type AppEventCreateContext = {
 export class AppEvent implements IAppEvent {
     readonly request: AppRequest;
 
-    readonly params: Record<string, any>;
+    readonly params: Record<string, string | undefined>;
 
     readonly path: string;
 
-    readonly method: string;
+    readonly method: MethodNameLike;
 
     readonly mountPath: string;
 

--- a/src/event/types.ts
+++ b/src/event/types.ts
@@ -1,5 +1,6 @@
 import type { ServerRequest } from 'srvx';
 import type { AppOptions } from '../app/types.ts';
+import type { MethodNameLike } from '../constants.ts';
 
 export type AppResponse = {
     status: number;
@@ -17,9 +18,13 @@ export interface IAppEvent {
     readonly request: AppRequest;
 
     /**
-     * Route parameters extracted from the URL path pattern.
+     * Route parameters extracted from the URL path pattern. Values
+     * are `string` (or `undefined` for an optional param that
+     * didn't match) — both the trie router (`extractTrieParams`)
+     * and the linear router (path-to-regexp output) only ever
+     * produce string values.
      */
-    readonly params: Record<string, any>;
+    readonly params: Record<string, string | undefined>;
 
     /**
      * Current request path, adjusted relative to the mount point during router nesting.
@@ -27,9 +32,12 @@ export interface IAppEvent {
     readonly path: string;
 
     /**
-     * HTTP method (GET, POST, PUT, etc.).
+     * HTTP method (GET, POST, PUT, etc.). Typed as the canonical
+     * `MethodName` set with an open-enum escape hatch — non-
+     * standard methods (`PROPFIND`, custom verbs) still type-check
+     * while standard ones autocomplete.
      */
-    readonly method: string;
+    readonly method: MethodNameLike;
 
     /**
      * Accumulated mount path from nested routers.

--- a/src/router/linear/module.ts
+++ b/src/router/linear/module.ts
@@ -1,4 +1,5 @@
 import type { ICache } from '../../cache/index.ts';
+import type { MethodNameLike } from '../../constants.ts';
 import type { IPathMatcher } from '../../path/index.ts';
 import type { ObjectLiteral, Route, RouteMatch } from '../../types.ts';
 import type { BaseRouterOptions, IRouter } from '../types.ts';
@@ -43,7 +44,7 @@ export class LinearRouter<T extends ObjectLiteral = ObjectLiteral> implements IR
         this.cache?.clear();
     }
 
-    lookup(path: string, _method?: string): readonly RouteMatch<T>[] {
+    lookup(path: string, _method?: MethodNameLike): readonly RouteMatch<T>[] {
         // LinearRouter ignores `method`: the dispatcher's own
         // `matchHandlerMethod` check runs on every returned candidate
         // anyway, so we simply emit every path-matching route and let
@@ -82,7 +83,7 @@ export class LinearRouter<T extends ObjectLiteral = ObjectLiteral> implements IR
                 // Prototype-less for symmetry with TrieRouter — avoids
                 // `__proto__` / `hasOwnProperty` shadowing if user
                 // code does `'foo' in match.params`.
-                params: Object.create(null) as Record<string, any>,
+                params: Object.create(null) as Record<string, string | undefined>,
             });
         }
 

--- a/src/router/trie/module.ts
+++ b/src/router/trie/module.ts
@@ -1,4 +1,5 @@
 import { MethodName } from '../../constants.ts';
+import type { MethodNameLike } from '../../constants.ts';
 import type { ICache } from '../../cache/index.ts';
 import type { ObjectLiteral, Route, RouteMatch } from '../../types.ts';
 import type { BaseRouterOptions, IRouter } from '../types.ts';
@@ -32,8 +33,8 @@ function decodeOrRaw(s: string): string {
 function extractTrieParams(
     segments: string[],
     indexMap: ParamCapture[],
-): Record<string, unknown> {
-    const out = Object.create(null) as Record<string, unknown>;
+): Record<string, string | undefined> {
+    const out = Object.create(null) as Record<string, string | undefined>;
     for (const cap of indexMap) {
         if (cap.kind === 'segment') {
             out[cap.name] = decodeOrRaw(segments[cap.depth]!);
@@ -109,7 +110,7 @@ function buildParamsIndexMap(segments: Segment[]): ParamCapture[] {
  * `IRouter.lookup(path)` (no method) keeps returning a complete
  * candidate set.
  */
-function methodBucketKeys(method: string | undefined): readonly string[] | null {
+function methodBucketKeys(method: MethodNameLike | undefined): readonly string[] | null {
     if (typeof method === 'undefined' || method === MethodName.OPTIONS) {
         return null;
     }
@@ -121,7 +122,7 @@ function methodBucketKeys(method: string | undefined): readonly string[] | null 
 
 function emitBucket<T extends ObjectLiteral>(
     buckets: MethodBuckets<T>,
-    method: string | undefined,
+    method: MethodNameLike | undefined,
     out: IndexedRoute<T>[],
 ): void {
     const keys = methodBucketKeys(method);
@@ -273,7 +274,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         this.cache?.clear();
     }
 
-    lookup(path: string, method?: string): readonly RouteMatch<T>[] {
+    lookup(path: string, method?: MethodNameLike): readonly RouteMatch<T>[] {
         // Cache key includes the method bucket — different methods at
         // the same path now resolve to different candidate sets, so
         // sharing a cache entry across methods would leak matches.
@@ -365,7 +366,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
             matches.push({
                 route,
                 index,
-                params: Object.create(null) as Record<string, unknown>,
+                params: Object.create(null) as Record<string, string | undefined>,
             });
             lastIndex = index;
         }
@@ -390,7 +391,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
      * encountered, returns `null` and the caller falls through to
      * the regular `walk`.
      */
-    protected shortCircuit(segments: string[], method: string | undefined): IndexedRoute<T>[] | null {
+    protected shortCircuit(segments: string[], method: MethodNameLike | undefined): IndexedRoute<T>[] | null {
         let node = this.root;
 
         for (const segment of segments) {
@@ -498,7 +499,7 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
         segments: string[],
         depth: number,
         collected: IndexedRoute<T>[],
-        method: string | undefined,
+        method: MethodNameLike | undefined,
     ): void {
         // Splats at this depth match any request path that reaches here.
         emitBucket(node.splatRoutes, method, collected);
@@ -540,8 +541,10 @@ export class TrieRouter<T extends ObjectLiteral = ObjectLiteral> implements IRou
      * lookups skip prototype-chain traversal and avoid `__proto__` /
      * `hasOwnProperty` shadowing from user-controlled segment values.
      */
-    protected assignParams(source: Record<string, unknown>): Record<string, unknown> {
-        const out = Object.create(null) as Record<string, unknown>;
+    protected assignParams(
+        source: Record<string, string | undefined>,
+    ): Record<string, string | undefined> {
+        const out = Object.create(null) as Record<string, string | undefined>;
         for (const k in source) {
             if (Object.prototype.hasOwnProperty.call(source, k)) {
                 out[k] = source[k];

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -1,4 +1,5 @@
 import type { ICache } from '../cache/index.ts';
+import type { MethodNameLike } from '../constants.ts';
 import type { ObjectLiteral, Route, RouteMatch } from '../types.ts';
 
 /**
@@ -68,7 +69,7 @@ export interface IRouter<T extends ObjectLiteral = ObjectLiteral> {
      * HEAD handling notes on `TrieRouter` for the canonical
      * implementation.
      */
-    lookup(path: string, method?: string): readonly RouteMatch<T>[];
+    lookup(path: string, method?: MethodNameLike): readonly RouteMatch<T>[];
 
     /**
      * Return a fresh, **empty** router of the same shape — same class

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,10 +62,11 @@ export type RouteMatch<T extends ObjectLiteral = ObjectLiteral> = {
      */
     index: number;
     /**
-     * Path params extracted from the route's matcher. Empty object
-     * when the route has no path or no params.
+     * Path params extracted from the route's matcher. Values are
+     * `string` (or `undefined` for an optional param that didn't
+     * match). Empty object when the route has no path or no params.
      */
-    params: Record<string, any>;
+    params: Record<string, string | undefined>;
     /**
      * For routes with a matcher: the path substring the matcher
      * consumed. Used by `executePipelineStepChildDispatch` to strip

--- a/test/unit/event/types.spec.ts
+++ b/test/unit/event/types.spec.ts
@@ -1,0 +1,54 @@
+import { 
+    describe, 
+    expect, 
+    expectTypeOf, 
+    it, 
+} from 'vitest';
+import type { MethodName, MethodNameLike } from '../../../src';
+import {
+    App,
+    defineCoreHandler,
+} from '../../../src';
+import { createTestRequest } from '../../helpers';
+
+/**
+ * Type-level locks on the v6 typing surface — these tests catch
+ * accidental loosening (back to plain `string` / `Record<string,
+ * any>`) that would otherwise pass the runtime suite.
+ */
+describe('IAppEvent typing', () => {
+    it('event.method is typed as MethodNameLike (autocomplete + open-enum)', async () => {
+        const app = new App();
+        let captured: MethodNameLike | undefined;
+        app.get('/x', defineCoreHandler((event) => {
+            captured = event.method;
+            // Type-level: assignable to MethodNameLike, accepts the
+            // canonical methods AND any other string.
+            expectTypeOf(event.method).toEqualTypeOf<MethodNameLike>();
+            return 'ok';
+        }));
+
+        const res = await app.fetch(createTestRequest('/x'));
+        expect(res.status).toBe(200);
+        // Runtime: the standard methods are uppercase; the
+        // canonical `MethodName` union covers them.
+        expect(captured satisfies MethodName).toBe('GET');
+    });
+
+    it('event.params values are string | undefined', async () => {
+        const app = new App();
+        let captured: Record<string, string | undefined> | undefined;
+        app.get('/users/:id', defineCoreHandler((event) => {
+            captured = event.params;
+            // Type-level: declared params are string-or-undefined.
+            // The undefined accommodates optional params; in this
+            // route `id` is mandatory at runtime.
+            expectTypeOf(event.params).toEqualTypeOf<Record<string, string | undefined>>();
+            return event.params.id ?? '';
+        }));
+
+        const res = await app.fetch(createTestRequest('/users/42'));
+        expect(await res.text()).toBe('42');
+        expect(captured).toEqual({ id: '42' });
+    });
+});

--- a/test/unit/event/types.spec.ts
+++ b/test/unit/event/types.spec.ts
@@ -30,9 +30,11 @@ describe('IAppEvent typing', () => {
 
         const res = await app.fetch(createTestRequest('/x'));
         expect(res.status).toBe(200);
-        // Runtime: the standard methods are uppercase; the
-        // canonical `MethodName` union covers them.
-        expect(captured satisfies MethodName).toBe('GET');
+        // Runtime: the standard methods are uppercase; assert the
+        // captured value is in the canonical `MethodName` set.
+        expect(captured).toBe('GET');
+        const captured2: MethodName = 'GET';
+        expect(captured2).toBe(captured);
     });
 
     it('event.params values are string | undefined', async () => {


### PR DESCRIPTION
## Summary

Two related changes that narrow the public type surface without changing runtime behaviour.

### \`event.method\`: \`string\` → \`MethodNameLike\`

\`MethodNameLike\` = \`MethodName | (string & {})\` — the canonical set (\`'GET' | 'POST' | …\`) with an open-enum escape hatch:

- Standard methods autocomplete on \`event.method\`.
- Non-standard verbs (\`PROPFIND\`, \`MKCOL\`, custom) still type-check (the \`(string & {})\` intersection is structurally identical to \`string\` but TypeScript doesn't collapse the union).

Applied to \`IAppEvent.method\`, \`IDispatcherEvent.method\`, \`AppEventCreateContext.method\`, and \`IRouter.lookup(path, method?)\`.

### \`event.params\`: \`Record<string, any>\` → \`Record<string, string | undefined>\`

Both routers only ever produce string values — path-to-regexp output for \`LinearRouter\`, \`extractTrieParams\` for \`TrieRouter\`. The \`undefined\` accommodates optional params (\`/users/:id?\`) that didn't match. Catches things like \`event.params.id.toUpperCase()\` (which silently \`any\`'d through before) at compile time.

Same change on \`RouteMatch.params\`, \`IDispatcherEvent.params\`, \`AppEventCreateContext.params\`, and the trie's \`extractTrieParams\` / \`assignParams\` helpers.

## Migration

- TS users reading \`event.params.id\` now get \`string | undefined\` — add a \`?? ''\` / \`!\` / nullish check for paths where the param is mandatory.
- TS users \`switch\`ing on \`event.method\` against \`MethodName\` need a \`default\` branch.
- JS / runtime behaviour is unchanged.

## Test plan

- [x] All 385 unit tests pass (2 new type-level locks in \`event/types.spec.ts\` using \`expectTypeOf\`)
- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type precision for HTTP method parameters with enhanced IDE autocomplete support for standard methods.
  * Refined route parameter typing to correctly represent optional parameters and their values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/routup/routup/pull/909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->