### PR TITLE
fix(bench): update server.mjs to v6 `AppContext` constructor shape

### DIFF
--- a/benchmark/server.mjs
+++ b/benchmark/server.mjs
@@ -22,7 +22,7 @@ const buildRouter = () => {
 };
 
 const app = new App({
-    etag: false,
+    options: { etag: false },
     router: buildRouter(),
 });
 


### PR DESCRIPTION
\`benchmark/server.mjs\` still used the v5 flat constructor shape:
\`\`\`ts
new App({ etag: false, router: ... })
\`\`\`
Plan 018 moved \`etag\` under \`options:\`, so the bench server ran with the default ETag fn enabled instead (silent regression of the bench's \"no ETag overhead\" baseline). Switched to:
\`\`\`ts
new App({ options: { etag: false }, router: ... })
\`\`\`

## Test plan
- [x] \`node benchmark/server.mjs\` boots and serves \`/api/v1/health\`
- [x] \`URL=http://127.0.0.1:3000/api/v1/health RESOLVER=trie node benchmark/run.mjs\` produces numbers end-to-end