### PR TITLE
docs(migration-v6): drop stale rename rows for types never shipped in v6

### DIFF
--- a/docs/src/guide/migration-v6.md
+++ b/docs/src/guide/migration-v6.md
@@ -10,10 +10,9 @@ Routup v6 also removes the lifecycle-hook surface (`app.on(...)`, `HookName`, pe
 |----|-----|
 | `new Router()` | `new App()` |
 | `IRouter` (top-level interface) | `IApp` |
-| `RouterOptions` / `RouterOptionsInput` | `AppOptions` / `AppOptionsInput`; the `App` constructor takes `AppContext` (`{ name, path, options, plugins, router }`) |
+| `RouterOptions` / `RouterOptionsInput` | `AppOptions` / `AppOptionsInput`; the `App` constructor takes `AppContext` (`{ name, path, options, router }`) |
 | `app.on(...)` / `app.off(...)`, `HookName.*` | _removed_ — express lifecycle wrapping as middleware (see [Middleware Patterns](./middleware-patterns) and the "Hooks removed" section below) |
 | `HandlerOptions.onBefore` / `onAfter` / `onError` | **kept** — but as plain optional callbacks on the handler config, no `Hooks` machinery, no priorities |
-| `RouteEntry` / `AppRouteEntry` / `HandlerRouteEntry` / `RouteEntryType` | _removed_ — `App` now stores routes as `Route<Handler>` directly; with sub-apps flattened at mount time there is no `APP` discriminator |
 | `RoutupEvent` / `IRoutupEvent` | `AppEvent` / `IAppEvent` |
 | `RoutupError` | `AppError` |
 | `RoutupRequest` | `AppRequest` |
@@ -25,10 +24,11 @@ Routup v6 also removes the lifecycle-hook surface (`app.on(...)`, `HookName`, pe
 | `RouterOptions.path` (runtime path-strip) | `AppContext.path` (registration-time **prefix**) |
 | `event.routerPath` | _removed_ — option resolution moved to mount time; the per-request stack walk is gone |
 | `event.routerOptions` | `event.appOptions` |
-| `RouterPipelineStep` / `RouterPipelineContext` / `RouterStackEntryType` / `RouterSymbol` | `AppPipelineStep` / `AppPipelineContext` / `RouteEntryType` / `AppSymbol` |
-| `RouterStackEntryType.ROUTER` (enum value) | `RouteEntryType.APP` |
-| `Router.StackEntry` | `RouteEntry` (`AppRouteEntry` \| `HandlerRouteEntry`) |
-| `isRouterInstance()` | `isAppInstance()` |
+| `Router.clone()` | _removed_ — sub-apps flatten on mount, so an App can be re-mounted under multiple paths without cloning (#914) |
+
+### Internal-only renames
+
+The v5 dispatch pipeline exposed `RouterPipelineStep`, `RouterPipelineContext`, `RouterStackEntryType`, `Router.StackEntry`, `RouterSymbol`, and `isRouterInstance` from internal module paths. v6 reorganized the dispatch entirely — the App now stores routes as `Route<Handler>` directly and there is no per-request stack, so the corresponding types are gone. The public re-exports (`Route`, `RouteMatch`, `App`, `IApp`) are stable; only code that imported from non-barrel paths is affected.
 
 ## Renames at a glance
 


### PR DESCRIPTION
## Summary

Pre-release readiness pass on \`docs/src/guide/migration-v6.md\`. The v5→v6 rename table accumulated rows during the beta cycle that referenced 'v6' identifiers which never actually shipped — they were intermediate renames dropped along the way (some via #914, some via the \`AppPipelineContext\` removal in 1d0ae27, others that were never publicly exposed in v6 at all). For someone upgrading from v5 the table currently sends them looking for types that don't exist.

## Changes

| Row | Action | Why |
|---|---|---|
| \`AppContext\` cell | Drop \`plugins\` field | Removed in #914 alongside \`clone()\` |
| \`RouteEntry / AppRouteEntry / HandlerRouteEntry / RouteEntryType\` | Removed | None exist in v6. v6 stores routes as \`Route<Handler>\` directly; v5's entry hierarchy was dropped, not renamed |
| \`AppPipelineStep / AppPipelineContext / RouteEntryType / AppSymbol\` | Removed | \`AppPipelineContext\` dropped in 1d0ae27; \`RouteEntryType\` and \`AppPipelineStep\` never shipped; \`AppSymbol\` is internal-only |
| \`RouterStackEntryType.ROUTER → RouteEntryType.APP\` | Removed | Same reason |
| \`Router.StackEntry → RouteEntry (...)\` | Removed | Same reason |
| \`isRouterInstance() → isAppInstance()\` | Moved to "Internal-only renames" subsection | Both functions are internal in v6, not on the public barrel — was misleading as a public-API rename |
| \`Router.clone() → removed\` | **Added** | Was missing entirely; should be in the table for users upgrading from 5.2.0 (which shipped \`clone()\`) |

Also added a short "Internal-only renames" subsection that's honest about which v5 internals had no v6 public equivalent.

## Test plan

- [x] \`npm run build:types\` — clean (no source changes; type-check ran to confirm nothing depended on a now-undocumented identifier)
- [x] Grep verified no remaining \`plugins\` / \`RouteEntryType\` / \`StackEntry\` references in the doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v6 migration guide documenting core API changes: Router renamed to App, RouterOptions to AppOptions
  * App constructor signature changed to accept AppContext object containing name, path, options, and router
  * Removed app lifecycle hook API methods (app.on/app.off)
  * Handler callbacks (onBefore, onAfter, onError) are now simplified as plain optional callbacks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/routup/routup/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->