### PR TITLE
refactor(dispatch): drop unreachable mid-pipeline path-rewrite branch

### DIFF
--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -312,7 +312,7 @@ export class App implements IApp {
 
         try {
             const matches = this.router.lookup(event.path, event.method);
-            response = await this.runMatches(event, matches, event.path, 0);
+            response = await this.runMatches(event, matches, 0);
 
             // OPTIONS auto-Allow synthesis — runs only on the root and
             // only when no handler produced a response or an error.
@@ -361,11 +361,18 @@ export class App implements IApp {
      * Walk the matched routes for the current event, dispatching each
      * handler in order. Re-entered (recursively) from the `setNext`
      * continuation so `event.next()` resumes from the next match.
+     *
+     * The match list is captured once per dispatch — there is no
+     * mid-walk path-rewrite refresh. `IAppEvent.path` is a snapshot
+     * on the handler's facade event (see `event/module.ts`), so user
+     * middleware cannot mutate the dispatcher's path before calling
+     * `event.next()`. If a future API surface lets middleware rewrite
+     * paths end-to-end, this loop will need a per-call refresh + a
+     * `methodsAllowed` reset (see closed issue #913).
      */
     protected async runMatches(
         event: IDispatcherEvent,
         matches: readonly RouteMatch<Handler>[],
-        matchesPath: string,
         startIndex: number,
     ): Promise<Response | undefined> {
         let i = startIndex;
@@ -409,25 +416,13 @@ export class App implements IApp {
             }
 
             const capturedMatches = matches;
-            const capturedMatchesPath = matchesPath;
             const nextIndex = i + 1;
 
             event.setNext(async (error?: Error) => {
                 if (error) {
                     event.error = createError(error);
                 }
-
-                // If the handler mutated `event.path` before calling
-                // next(), the captured matches are stale — refresh on
-                // the new path. Otherwise resume from the next match.
-                const pathChanged = event.path !== capturedMatchesPath;
-                const nextMatches = pathChanged ?
-                    this.router.lookup(event.path, event.method) :
-                    capturedMatches;
-                const nextMatchesPath = pathChanged ? event.path : capturedMatchesPath;
-                const nextStart = pathChanged ? 0 : nextIndex;
-
-                return this.runMatches(event, nextMatches, nextMatchesPath, nextStart);
+                return this.runMatches(event, capturedMatches, nextIndex);
             });
 
             try {


### PR DESCRIPTION
## Summary

\`App.runMatches.setNext\` carried a \`pathChanged\` check that re-ran \`router.lookup\` whenever the dispatcher event's path differed from the captured matches path. In v6 that branch is **dead from user code**: the handler-facing \`AppEvent.path\` is a snapshot of the dispatcher event at \`build()\` time, so user middleware can't mutate the dispatcher's path through it. The check only fires if framework code rewrote \`event.path\` between captures — which no v6 code path does.

## Why now

Dead code in the dispatch hot path is a maintenance liability — someone debugging assumes it works and burns time. While investigating #913 (where a reviewer flagged that \`event.methodsAllowed\` accumulates across a pre-rewrite path), I traced the snapshot architecture and confirmed the bug isn't reachable. Removing the branch makes what v6 supports explicit rather than carrying half-finished plumbing.

## Changes

- Drop the \`pathChanged\` / refresh-lookup / \`methodsAllowed\` reset blocks from \`setNext\`.
- Drop the \`matchesPath\` parameter from \`runMatches\`. The dispatch caller no longer passes \`event.path\`.
- Drop the \`capturedMatchesPath\` local.
- Add a docstring on \`runMatches\` calling out the snapshot architecture and noting that any future path-rewrite API will need to re-introduce both the refresh and a \`methodsAllowed\` reset (the original concern from #913).

Net: 10 inserted, 15 deleted.

## Closes

Closes #913 — the \`OPTIONS\` Allow-header accumulation bug isn't reachable in v6 because the path-rewrite scenario it depends on requires capabilities user middleware doesn't have.

## Test plan

- [x] \`npm run build\` — JS bundle + \`tsc --noEmit\` clean
- [x] \`npm run lint\` — clean (5 pre-existing \`no-console\` warnings in \`benchmark/run.mjs\` unrelated)
- [x] \`npm test\` — 377/377 passing across 51 files (no test changes; existing OPTIONS auto-Allow coverage at \`compliance.spec.ts\` and \`methods.spec.ts\` keeps the behaviour pinned)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal optimizations with no user-facing changes. The event routing system has been streamlined to simplify how route matching is handled during event dispatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/routup/routup/pull/920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->