### PR TITLE
feat(response): expose createContentDisposition / parseContentDisposition

### DIFF
--- a/docs/src/api/response-helpers.md
+++ b/docs/src/api/response-helpers.md
@@ -157,13 +157,17 @@ createContentDisposition('€ rates.pdf', { type: 'inline' });
 
 ### `parseContentDisposition`
 
-Parse a `Content-Disposition` header value into its type and parameters, decoding RFC 5987 / RFC 8187 extended parameters by default.
+Parse a `Content-Disposition` header value into its type and parameters, decoding RFC 5987 / RFC 8187 extended parameters by default. Accepts `null` / `undefined` (as returned by `Headers.get()` when the header is absent) and returns `null` in that case, so callers don't need a separate null-check.
 
 ```typescript
 declare function parseContentDisposition(
     header: string,
     options?: ContentDispositionParseOptions,
 ): ContentDisposition;
+declare function parseContentDisposition(
+    header: string | null | undefined,
+    options?: ContentDispositionParseOptions,
+): ContentDisposition | null;
 
 type ContentDisposition = {
     type: string;
@@ -182,6 +186,9 @@ parseContentDisposition('attachment; filename="plans.pdf"');
 
 parseContentDisposition("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf");
 // { type: 'attachment', parameters: { filename: '€ rates.pdf' } }
+
+parseContentDisposition(event.request.headers.get('content-disposition'));
+// null when the header is missing
 ```
 
 If the underlying parser throws, the error is rethrown as an `AppError` with HTTP status `400` and the original error attached as `cause` — suitable for surfacing through routup's error handler when parsing untrusted request headers.

--- a/docs/src/api/response-helpers.md
+++ b/docs/src/api/response-helpers.md
@@ -131,6 +131,61 @@ setResponseHeaderInline(event, 'invoice.pdf');
 // Content-Disposition: inline; filename=invoice.pdf
 ```
 
+### `createContentDisposition`
+
+Build a `Content-Disposition` header value as a string, with RFC 6266 / RFC 5987 encoding for non-US-ASCII filenames. Pure function — does not touch the event. Use this when you need the raw header value (e.g. inside a multipart writer) rather than mutating `event.response.headers`.
+
+```typescript
+declare function createContentDisposition(
+    filename?: string,
+    options?: ContentDispositionCreateOptions,
+): string;
+
+type ContentDispositionCreateOptions = {
+    type?: 'attachment' | 'inline'; // default: 'attachment'
+    fallback?: string | boolean;    // default: true
+};
+```
+
+```typescript
+createContentDisposition('plans.pdf');
+// 'attachment; filename=plans.pdf'
+
+createContentDisposition('€ rates.pdf', { type: 'inline' });
+// "inline; filename=\"? rates.pdf\"; filename*=UTF-8''%E2%82%AC%20rates.pdf"
+```
+
+### `parseContentDisposition`
+
+Parse a `Content-Disposition` header value into its type and parameters, decoding RFC 5987 / RFC 8187 extended parameters by default.
+
+```typescript
+declare function parseContentDisposition(
+    header: string,
+    options?: ContentDispositionParseOptions,
+): ContentDisposition;
+
+type ContentDisposition = {
+    type: string;
+    parameters: Record<string, string>;
+};
+
+type ContentDispositionParseOptions = {
+    extended?: boolean;  // decode filename*=; default: true
+    multipart?: boolean; // multipart/form-data grammar; default: false
+};
+```
+
+```typescript
+parseContentDisposition('attachment; filename="plans.pdf"');
+// { type: 'attachment', parameters: { filename: 'plans.pdf' } }
+
+parseContentDisposition("attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf");
+// { type: 'attachment', parameters: { filename: '€ rates.pdf' } }
+```
+
+If the underlying parser throws, the error is rethrown as an `AppError` with HTTP status `400` and the original error attached as `cause` — suitable for surfacing through routup's error handler when parsing untrusted request headers.
+
 ### `setResponseHeaderContentType`
 
 Set the `Content-Type` response header. Optionally skip if a content type is already set.

--- a/docs/src/guide/helpers.md
+++ b/docs/src/guide/helpers.md
@@ -29,6 +29,8 @@ Helpers are standalone, tree-shakeable functions for interacting with requests a
 | `setResponseHeaderInline(event, filename?)` | Set Content-Disposition inline |
 | `setResponseHeaderContentType(event, type)` | Set Content-Type header |
 | `appendResponseHeader(event, name, value)` | Append to a response header |
+| `createContentDisposition(filename?, options?)` | Build a Content-Disposition header value |
+| `parseContentDisposition(header, options?)` | Parse a Content-Disposition header value |
 
 ## Event Properties
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
             "dependencies": {
                 "@ebec/core": "^1.1.0",
                 "@ebec/http": "^4.1.0",
+                "content-disposition": "^2.0.0",
                 "mime-explorer": "^1.1.0",
                 "negotiator": "^1.0.0",
                 "path-to-regexp": "^8.4.2",
@@ -3415,6 +3416,19 @@
             "dependencies": {
                 "array-ify": "^1.0.0",
                 "dot-prop": "^5.1.0"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.0.tgz",
+            "integrity": "sha512-qqGFOrKmFP1lTfG24opOJFcTMza1BqyTSUKVbMGUP5uRsBH+C00Q1loOk+JSFshyRE0ji4HtCJeNN2WHWd6PGw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/conventional-changelog-angular": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "dependencies": {
         "@ebec/core": "^1.1.0",
         "@ebec/http": "^4.1.0",
+        "content-disposition": "^2.0.0",
         "mime-explorer": "^1.1.0",
         "negotiator": "^1.0.0",
         "path-to-regexp": "^8.4.2",

--- a/src/response/helpers/header-disposition.ts
+++ b/src/response/helpers/header-disposition.ts
@@ -4,7 +4,7 @@ import { AppError } from '../../error/index.ts';
 import type { IAppEvent } from '../../event/index.ts';
 import { setResponseContentTypeByFileName } from './utils.ts';
 
-export type ContentDispositionType = 'attachment' | 'inline';
+export type ContentDispositionType = 'attachment' | 'inline' | (string & {});
 
 export type ContentDisposition = {
     type: string;
@@ -14,11 +14,13 @@ export type ContentDisposition = {
 export type ContentDispositionCreateOptions = {
     /**
      * The disposition type to emit. Defaults to `'attachment'`.
+     * Common HTTP response values are `'attachment'` and `'inline'`,
+     * but any token (e.g. `'form-data'` for multipart bodies) is accepted.
      */
     type?: ContentDispositionType;
     /**
      * Fallback filename for the legacy `filename` parameter when the input
-     * contains non-US-ASCII characters (a RFC 5987 `filename*` is always
+     * contains non-US-ASCII characters (an RFC 5987 `filename*` is always
      * emitted alongside it).
      *
      * - `true` (default): auto-generate by replacing non-ASCII with `?`.
@@ -51,7 +53,19 @@ export function createContentDisposition(
 export function parseContentDisposition(
     header: string,
     options?: ContentDispositionParseOptions,
-): ContentDisposition {
+): ContentDisposition;
+export function parseContentDisposition(
+    header: string | null | undefined,
+    options?: ContentDispositionParseOptions,
+): ContentDisposition | null;
+export function parseContentDisposition(
+    header: string | null | undefined,
+    options?: ContentDispositionParseOptions,
+): ContentDisposition | null {
+    if (header === null || header === undefined) {
+        return null;
+    }
+
     try {
         return parse(header, options && {
             extended: options.extended,

--- a/src/response/helpers/header-disposition.ts
+++ b/src/response/helpers/header-disposition.ts
@@ -1,69 +1,90 @@
+import { create, parse } from 'content-disposition';
 import { HeaderName } from '../../constants.ts';
+import { AppError } from '../../error/index.ts';
 import type { IAppEvent } from '../../event/index.ts';
 import { setResponseContentTypeByFileName } from './utils.ts';
 
-// eslint-disable-next-line no-control-regex
-const ENCODE_URL_ATTR_CHAR_REGEXP = /[\x00-\x20"'()*,/:;<=>?@[\\\]{}\x7f]/g;
-const NON_ASCII_REGEXP = /[^\x20-\x7e]/g;
-const QUOTE_REGEXP = /[\\"]/g;
-const HEX_ESCAPE_REGEXP = /%[0-9A-Fa-f]{2}/;
-const ASCII_TEXT_REGEXP = /^[\x20-\x7e]+$/;
-const TOKEN_REGEXP = /^[!#$%&'*+.0-9A-Z^_`a-z|~-]+$/;
+export type ContentDispositionType = 'attachment' | 'inline';
 
-function pencode(char: string): string {
-    return `%${char.charCodeAt(0).toString(16).toUpperCase()}`;
+export type ContentDisposition = {
+    type: string;
+    parameters: Record<string, string>;
+};
+
+export type ContentDispositionCreateOptions = {
+    /**
+     * The disposition type to emit. Defaults to `'attachment'`.
+     */
+    type?: ContentDispositionType;
+    /**
+     * Fallback filename for the legacy `filename` parameter when the input
+     * contains non-US-ASCII characters (a RFC 5987 `filename*` is always
+     * emitted alongside it).
+     *
+     * - `true` (default): auto-generate by replacing non-ASCII with `?`.
+     * - `false`: omit the legacy fallback (`filename*` only).
+     * - `string`: use the provided value verbatim.
+     */
+    fallback?: string | boolean;
+};
+
+export type ContentDispositionParseOptions = {
+    /**
+     * Decode RFC 5987 / RFC 8187 percent-encoded extended parameters
+     * (e.g. `filename*=UTF-8''...`). Defaults to `true`.
+     */
+    extended?: boolean;
+    /**
+     * Parse parameters using the relaxed grammar browsers send in
+     * `multipart/form-data` bodies. Defaults to `false`.
+     */
+    multipart?: boolean;
+};
+
+export function createContentDisposition(
+    filename?: string,
+    options?: ContentDispositionCreateOptions,
+): string {
+    return create(filename, options);
 }
 
-function quoteString(value: string): string {
-    return `"${value.replace(QUOTE_REGEXP, '\\$&')}"`;
-}
-
-function getAscii(value: string): string {
-    return value.replace(NON_ASCII_REGEXP, '?');
-}
-
-function encodeExtended(value: string): string {
-    return encodeURIComponent(value).replace(ENCODE_URL_ATTR_CHAR_REGEXP, pencode);
-}
-
-function formatFilename(value: string): string {
-    if (TOKEN_REGEXP.test(value)) {
-        return `filename=${value}`;
+export function parseContentDisposition(
+    header: string,
+    options?: ContentDispositionParseOptions,
+): ContentDisposition {
+    try {
+        return parse(header, options && {
+            extended: options.extended,
+            multipart: options.multipart,
+        });
+    } catch (cause) {
+        throw new AppError({
+            status: 400,
+            message: 'Invalid Content-Disposition header.',
+            cause,
+        });
     }
-    return `filename=${quoteString(value)}`;
 }
 
-function setDisposition(
+function setContentDisposition(
     event: IAppEvent,
-    type: 'attachment' | 'inline',
+    type: ContentDispositionType,
     filename?: string,
 ) {
-    let disposition: string = type;
-
     if (typeof filename === 'string') {
         setResponseContentTypeByFileName(event, filename);
-
-        const isAsciiSafe = ASCII_TEXT_REGEXP.test(filename) &&
-            !HEX_ESCAPE_REGEXP.test(filename);
-
-        if (isAsciiSafe) {
-            disposition += `; ${formatFilename(filename)}`;
-        } else {
-            disposition += `; ${formatFilename(getAscii(filename))}`;
-            disposition += `; filename*=UTF-8''${encodeExtended(filename)}`;
-        }
     }
 
     event.response.headers.set(
         HeaderName.CONTENT_DISPOSITION,
-        disposition,
+        createContentDisposition(filename, { type }),
     );
 }
 
 export function setResponseHeaderAttachment(event: IAppEvent, filename?: string) {
-    setDisposition(event, 'attachment', filename);
+    setContentDisposition(event, 'attachment', filename);
 }
 
 export function setResponseHeaderInline(event: IAppEvent, filename?: string) {
-    setDisposition(event, 'inline', filename);
+    setContentDisposition(event, 'inline', filename);
 }

--- a/test/unit/response/header-disposition.spec.ts
+++ b/test/unit/response/header-disposition.spec.ts
@@ -156,10 +156,18 @@ describe('src/helpers/response/header-disposition (jshttp/content-disposition pa
             expect(parsed.parameters['filename*']).toBe("UTF-8''%E2%82%AC%20rates.pdf");
         });
 
+        it('should return null when header is null', () => {
+            expect(parseContentDisposition(null)).toBeNull();
+        });
+
+        it('should return null when header is undefined', () => {
+            expect(parseContentDisposition(undefined)).toBeNull();
+        });
+
         it('should rethrow underlying parse errors as AppError 400', () => {
             let caught: unknown;
             try {
-                parseContentDisposition(null as unknown as string);
+                parseContentDisposition(123 as unknown as string);
             } catch (error) {
                 caught = error;
             }

--- a/test/unit/response/header-disposition.spec.ts
+++ b/test/unit/response/header-disposition.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+    AppError,
     HeaderName,
+    createContentDisposition,
+    parseContentDisposition,
     setResponseHeaderAttachment,
     setResponseHeaderInline,
 } from '../../../src';
@@ -112,6 +115,58 @@ describe('src/helpers/response/header-disposition (jshttp/content-disposition pa
         it('should handle Unicode', () => {
             expect(dispositionFor('€%20£.pdf'))
                 .toEqual('attachment; filename="?%20?.pdf"; filename*=UTF-8\'\'%E2%82%AC%2520%C2%A3.pdf');
+        });
+    });
+
+    describe('createContentDisposition', () => {
+        it('should default to attachment type', () => {
+            expect(createContentDisposition('plans.pdf'))
+                .toEqual('attachment; filename=plans.pdf');
+        });
+
+        it('should accept an inline type', () => {
+            expect(createContentDisposition('plans.pdf', { type: 'inline' }))
+                .toEqual('inline; filename=plans.pdf');
+        });
+
+        it('should build a header without filename', () => {
+            expect(createContentDisposition()).toEqual('attachment');
+        });
+    });
+
+    describe('parseContentDisposition', () => {
+        it('should parse a simple attachment header', () => {
+            expect(parseContentDisposition('attachment; filename="plans.pdf"'))
+                .toEqual({ type: 'attachment', parameters: { filename: 'plans.pdf' } });
+        });
+
+        it('should parse an RFC 5987 extended filename', () => {
+            const parsed = parseContentDisposition(
+                "attachment; filename=\"? rates.pdf\"; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+            );
+            expect(parsed.type).toBe('attachment');
+            expect(parsed.parameters.filename).toBe('€ rates.pdf');
+        });
+
+        it('should honour extended: false', () => {
+            const parsed = parseContentDisposition(
+                "attachment; filename*=UTF-8''%E2%82%AC%20rates.pdf",
+                { extended: false },
+            );
+            expect(parsed.parameters['filename*']).toBe("UTF-8''%E2%82%AC%20rates.pdf");
+        });
+
+        it('should rethrow underlying parse errors as AppError 400', () => {
+            let caught: unknown;
+            try {
+                parseContentDisposition(null as unknown as string);
+            } catch (error) {
+                caught = error;
+            }
+
+            expect(caught).toBeInstanceOf(AppError);
+            expect((caught as AppError).statusCode).toBe(400);
+            expect((caught as AppError).cause).toBeInstanceOf(TypeError);
         });
     });
 


### PR DESCRIPTION
## Summary

- Replace the internal Content-Disposition encoder with the well-maintained `jshttp/content-disposition` package (v2.0.0, zero runtime deps, ships its own types).
- Expose thin `createContentDisposition` and `parseContentDisposition` wrappers (plus `ContentDisposition` / option types) so plugins — notably routup/plugins#760 — can build and parse the header without depending on the upstream package directly.
- `parseContentDisposition` rethrows underlying parse errors as `AppError(400)` with the original error attached as `cause`, so failures surface cleanly through routup's error handler when parsing untrusted request headers.
- `setResponseHeaderAttachment` / `setResponseHeaderInline` retain their existing behaviour and output byte-for-byte (the existing parity tests verify this).

## Test plan

- [x] `npm test` — 379 tests pass (21 existing parity cases + 6 new for the wrappers + error mapping)
- [x] `npm run build:types` — clean
- [x] `npm run lint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helper functions for creating and parsing Content-Disposition response headers with support for both ASCII and non-ASCII filenames.

* **Documentation**
  * New API documentation for response header helpers.
  * Updated guide to include new helper functions.

* **Tests**
  * Added unit tests for new Content-Disposition handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/routup/routup/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->