### PR TITLE
fix(app): stop re-walking consumed match suffixes in runMatches

### DIFF
--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -418,11 +418,27 @@ export class App implements IApp {
             const capturedMatches = matches;
             const nextIndex = i + 1;
 
+            // Consumption of THIS iteration's continuation is tracked in a
+            // closure: the dispatcher's `_nextCalled` guard is a single
+            // shared field that every deeper `setNext` resets, so after the
+            // dispatch returns it reflects the deepest walked level — not
+            // whether this handler called its `next()`. The same closure
+            // also restores the double-invocation guard across the
+            // recursion (a second `next()` at this level replays the cached
+            // walk instead of re-running it).
+            let nextResult: Promise<Response | undefined> | undefined;
+
             event.setNext(async (error?: Error) => {
+                if (nextResult) {
+                    return nextResult;
+                }
+
                 if (error) {
                     event.error = createError(error);
                 }
-                return this.runMatches(event, capturedMatches, nextIndex);
+
+                nextResult = this.runMatches(event, capturedMatches, nextIndex);
+                return nextResult;
             });
 
             try {
@@ -431,6 +447,18 @@ export class App implements IApp {
                 if (dispatchResponse) {
                     response = dispatchResponse;
                     event.dispatched = true;
+                } else if (nextResult) {
+                    // The handler consumed its continuation: matches
+                    // `nextIndex..end` were already walked (recursively)
+                    // and produced no response. Falling through to `i++`
+                    // would walk the same suffix AGAIN — exponentially so
+                    // for a chain of next()-calling middlewares on a
+                    // request nothing answers (#946). The walk is
+                    // complete; stop here. (A handler that THROWS after
+                    // calling next() still falls through via the catch —
+                    // an error handler later in the chain must see the
+                    // error.)
+                    break;
                 }
             } catch (e) {
                 event.error = createError(e);

--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -431,12 +431,17 @@ export class App implements IApp {
             let nextResult: Promise<Response | undefined> | undefined;
 
             event.setNext(async (error?: Error) => {
-                if (nextResult) {
-                    return nextResult;
-                }
-
+                // Record the error BEFORE the cache short-circuit: even on
+                // the (defensively guarded, normally unreachable) replay of
+                // an already-consumed continuation, an error argument is a
+                // signal the walk must not silently discard — the loop's
+                // error-state skip logic picks it up either way.
                 if (error) {
                     event.error = createError(error);
+                }
+
+                if (nextResult) {
+                    return nextResult;
                 }
 
                 nextResult = this.runMatches(event, capturedMatches, nextIndex);

--- a/src/app/module.ts
+++ b/src/app/module.ts
@@ -422,10 +422,12 @@ export class App implements IApp {
             // closure: the dispatcher's `_nextCalled` guard is a single
             // shared field that every deeper `setNext` resets, so after the
             // dispatch returns it reflects the deepest walked level — not
-            // whether this handler called its `next()`. The same closure
-            // also restores the double-invocation guard across the
-            // recursion (a second `next()` at this level replays the cached
-            // walk instead of re-running it).
+            // whether this handler called its `next()`. (The early-return on
+            // a set `nextResult` is defensive only: under the current
+            // dispatcher invariants a consumed continuation cannot be
+            // re-invoked — the facade guard dedupes same-handler double
+            // next() calls, and `setNext` replaces `_next` whenever it
+            // resets `_nextCalled`.)
             let nextResult: Promise<Response | undefined> | undefined;
 
             event.setNext(async (error?: Error) => {
@@ -457,7 +459,10 @@ export class App implements IApp {
                     // complete; stop here. (A handler that THROWS after
                     // calling next() still falls through via the catch —
                     // an error handler later in the chain must see the
-                    // error.)
+                    // error. Error flow is FORWARD-ONLY: an ERROR handler
+                    // registered BEFORE the failure point is not revisited
+                    // — the pre-#946 re-walk reached it by accident, and
+                    // multiple times.)
                     break;
                 }
             } catch (e) {

--- a/test/unit/routing/dispatch-count.spec.ts
+++ b/test/unit/routing/dispatch-count.spec.ts
@@ -67,7 +67,7 @@ describe('routing/dispatch-count', () => {
         expect(await response.text()).toEqual('post-next failure');
     });
 
-    it('should replay the cached walk when a middleware calls next() twice', async () => {
+    it('should dispatch downstream once when a middleware calls next() twice (facade dedupe)', async () => {
         const app = new App();
         let downstreamDispatched = 0;
 
@@ -86,5 +86,72 @@ describe('routing/dispatch-count', () => {
         await app.fetch(createTestRequest('/miss'));
 
         expect(downstreamDispatched).toEqual(1);
+    });
+
+    it('should dispatch a downstream error handler once per next(error)', async () => {
+        const app = new App();
+        let errorDispatched = 0;
+
+        app.use(defineCoreHandler((event) => event.next(new Error('boom'))));
+
+        app.use(defineErrorHandler((error, event) => {
+            errorDispatched++;
+
+            // pass the error along — no response, the walk used to re-enter
+            return event.next(error);
+        }));
+
+        await app.fetch(createTestRequest('/anything'));
+
+        expect(errorDispatched).toEqual(1);
+    });
+
+    it('should keep OPTIONS Allow synthesis intact (the suffix walk records methodsAllowed before the break)', async () => {
+        const app = new App();
+        let middlewareDispatched = 0;
+
+        app.use(defineCoreHandler((event) => {
+            middlewareDispatched++;
+
+            return event.next();
+        }));
+
+        app.get('/resource', defineCoreHandler(() => 'get'));
+        app.post('/resource', defineCoreHandler(() => 'post'));
+
+        const response = await app.fetch(createTestRequest('/resource', { method: 'OPTIONS' }));
+
+        const allow = (response.headers.get('allow') ?? '').split(',').sort();
+        expect(allow).toEqual(['GET', 'HEAD', 'POST']);
+        expect(middlewareDispatched).toEqual(1);
+    });
+
+    it('should NOT revisit an error handler registered before the failure point (forward-only error flow)', async () => {
+        // pre-#946 the exponential re-walk accidentally re-entered EARLIER
+        // error handlers (multiple times) after a later middleware threw.
+        // Error flow is forward-only now: only handlers after the failure
+        // point see the error; without one, the error surfaces as the
+        // fallback error response.
+        const app = new App();
+        let earlyErrorDispatched = 0;
+
+        app.use(defineCoreHandler((event) => event.next()));
+
+        app.use(defineErrorHandler(() => {
+            earlyErrorDispatched++;
+
+            return 'early-handler';
+        }));
+
+        app.use(defineCoreHandler(async (event) => {
+            await event.next();
+
+            throw new Error('post-next failure');
+        }));
+
+        const response = await app.fetch(createTestRequest('/anything'));
+
+        expect(earlyErrorDispatched).toEqual(0);
+        expect(response.status).toBeGreaterThanOrEqual(500);
     });
 });

--- a/test/unit/routing/dispatch-count.spec.ts
+++ b/test/unit/routing/dispatch-count.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+    App,
+    defineCoreHandler,
+    defineErrorHandler,
+} from '../../../src';
+import { createTestRequest } from '../../helpers';
+
+/**
+ * Regression coverage for #946: when no handler produced a response (an
+ * unmatched route), the match walk re-entered every next()-calling
+ * middleware once per remaining match — 2^k dispatches for the handler at
+ * match index k. A middleware chain must dispatch each handler exactly once
+ * per request, matched or not.
+ */
+describe('routing/dispatch-count', () => {
+    const build = (size: number) => {
+        const app = new App();
+        const counts: number[] = [];
+
+        for (let i = 0; i < size; i++) {
+            const index = i;
+            counts[index] = 0;
+            app.use(defineCoreHandler((event) => {
+                counts[index] = (counts[index] ?? 0) + 1;
+
+                return event.next();
+            }));
+        }
+
+        app.get('/hit', defineCoreHandler(() => 'ok'));
+
+        return { app, counts };
+    };
+
+    it('should dispatch each middleware once on a matched route', async () => {
+        const { app, counts } = build(10);
+
+        await app.fetch(createTestRequest('/hit'));
+
+        expect(counts).toEqual(new Array(10).fill(1));
+    });
+
+    it('should dispatch each middleware once on an unmatched route', async () => {
+        const { app, counts } = build(10);
+
+        await app.fetch(createTestRequest('/miss'));
+
+        expect(counts).toEqual(new Array(10).fill(1));
+    });
+
+    it('should still reach a later error handler when a middleware throws after next()', async () => {
+        const app = new App();
+
+        app.use(defineCoreHandler(async (event) => {
+            await event.next();
+
+            throw new Error('post-next failure');
+        }));
+
+        app.use(defineCoreHandler((event) => event.next()));
+
+        app.use(defineErrorHandler((error) => error.message));
+
+        const response = await app.fetch(createTestRequest('/anything'));
+
+        expect(await response.text()).toEqual('post-next failure');
+    });
+
+    it('should replay the cached walk when a middleware calls next() twice', async () => {
+        const app = new App();
+        let downstreamDispatched = 0;
+
+        app.use(defineCoreHandler(async (event) => {
+            await event.next();
+
+            return event.next();
+        }));
+
+        app.use(defineCoreHandler((event) => {
+            downstreamDispatched++;
+
+            return event.next();
+        }));
+
+        await app.fetch(createTestRequest('/miss'));
+
+        expect(downstreamDispatched).toEqual(1);
+    });
+});


### PR DESCRIPTION
Closes #946

## Problem

`App.runMatches` dispatches the handler at match index k **2^k times** on any request where no handler produces a response (a 404): a middleware that awaited `event.next()` already walked the remaining matches through the `setNext` continuation, but when that walk produced no response the loop still fell through to `i++` and walked the same suffix again. Only `event.dispatched` (set on a produced response) ever stopped the doubling.

Measured with 10 chained `next()`-calling middlewares: a matched route dispatches `1,1,1,1,1,1,1,1,1,1`; an unmatched route dispatched `1,2,4,8,16,32,64,128,256,512` (1023 total). Downstream impact in authup: the authorization middleware at match index 8–9 re-verified Basic credentials 128–256× per authenticated 404 (~4s of bcrypt).

## Fix

Track consumption of **this** iteration's continuation in a closure and stop the walk when the handler consumed its continuation without producing a response — the suffix walk is already complete.

The closure is load-bearing: the dispatcher's shared `_nextCalled` guard is reset by every deeper `setNext`, so after `handler.dispatch` returns it reflects the deepest walked level, not whether *this* handler called its `next()`. The closure also caches the continuation's promise, restoring the double-invocation guard across the recursion (a second `next()` at the same level replays the cached walk instead of re-running it).

Preserved semantics:
- a handler that **throws after** `next()` still falls through via the catch, so a later error handler sees the error (pinned by test);
- method/type skip fall-through (`continue` paths) is untouched;
- `toResponse`/undefined-return contracts are untouched (`resolveHandlerResult` already serializes the loop against late `next()` calls).

## Tests

New `test/unit/routing/dispatch-count.spec.ts`: exact dispatch counts on matched + unmatched routes (the unmatched case was `1,2,4,…,512` pre-fix), error-handler reachability after a post-`next()` throw, and the double-`next()` replay. Full suite 385 green, `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented middleware/match walking from re-running the remaining suffix after `next()` continuation reuse.
  - Ensured downstream handlers are dispatched only once, including when middleware chains are exercised multiple times or routes don’t match.
  - Improved middleware error propagation so the correct error handler runs without unintended extra dispatches.

- **Tests**
  - Expanded dispatch-count and routing assertions for matched/unmatched routes.
  - Added coverage for `next()` called twice, error after `next()`, and forward-only error-flow regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Behavior note (audit follow-up)

The break also makes error flow **forward-only**: an ERROR handler registered *before* the failure point is no longer revisited after a later middleware throws post-`next()`. The pre-fix re-walk reached such handlers only by accident — and dispatched them multiple times. This matches express-style error semantics (error handlers must be registered after the routes/middlewares they cover) but is an observable change; it is pinned by a dedicated test, alongside error-path and OPTIONS `Allow` dispatch-count pins. The closure's early-return is documented as defensive-only — under current dispatcher invariants a consumed continuation cannot be re-invoked (the facade guard dedupes same-handler double `next()` calls).
